### PR TITLE
Encapsulate an acceptable hashing algorithm

### DIFF
--- a/Bibliotek.xcodeproj/project.pbxproj
+++ b/Bibliotek.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		AA6D18D620B5B6CC00603E61 /* BibFetchRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = AA6D18D420B5B6CC00603E61 /* BibFetchRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA6D18D720B5B6CC00603E61 /* BibFetchRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = AA6D18D520B5B6CC00603E61 /* BibFetchRequest.m */; };
 		AA6D18D920B5B9FC00603E61 /* BibFetchRequest+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AA6D18D820B5B9FC00603E61 /* BibFetchRequest+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		AA99BAF62301E4370055C078 /* BibHasher.h in Headers */ = {isa = PBXBuildFile; fileRef = AA99BAF42301E4370055C078 /* BibHasher.h */; };
+		AA99BAF72301E4370055C078 /* BibHasher.m in Sources */ = {isa = PBXBuildFile; fileRef = AA99BAF52301E4370055C078 /* BibHasher.m */; };
 		AAA30B9C22F48F7900AF7AE5 /* BibMARCInputStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA30B9B22F48F7900AF7AE5 /* BibMARCInputStream.swift */; };
 		AAA4DFFD22EBD6DB0003AF7B /* BibMARCInputStream+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = AA19397A22E8E0F700429C54 /* BibMARCInputStream+Internal.h */; };
 		AAA4DFFF22EBE2780003AF7B /* BibMARCInputStreamTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AAA4DFFE22EBE2780003AF7B /* BibMARCInputStreamTests.m */; };
@@ -150,6 +152,8 @@
 		AA6D18D420B5B6CC00603E61 /* BibFetchRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BibFetchRequest.h; sourceTree = "<group>"; };
 		AA6D18D520B5B6CC00603E61 /* BibFetchRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BibFetchRequest.m; sourceTree = "<group>"; };
 		AA6D18D820B5B9FC00603E61 /* BibFetchRequest+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BibFetchRequest+Private.h"; sourceTree = "<group>"; };
+		AA99BAF42301E4370055C078 /* BibHasher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BibHasher.h; sourceTree = "<group>"; };
+		AA99BAF52301E4370055C078 /* BibHasher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BibHasher.m; sourceTree = "<group>"; };
 		AA9F66D120D0C0F000CE4DA7 /* Bibliotek.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Bibliotek.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		AAA30B9B22F48F7900AF7AE5 /* BibMARCInputStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BibMARCInputStream.swift; sourceTree = "<group>"; };
 		AAA4DFFE22EBE2780003AF7B /* BibMARCInputStreamTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BibMARCInputStreamTests.m; sourceTree = "<group>"; };
@@ -230,6 +234,8 @@
 				AA258AEE21FA2E1D00CDF88E /* NSCharacterSet+BibASCIICharacterSet.m */,
 				AA258AFA21FE3C2A00CDF88E /* NSString+BibCharacterSetValidation.h */,
 				AA258AFB21FE3C2A00CDF88E /* NSString+BibCharacterSetValidation.m */,
+				AA99BAF42301E4370055C078 /* BibHasher.h */,
+				AA99BAF52301E4370055C078 /* BibHasher.m */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -407,6 +413,7 @@
 				AABDC20B22DAC17A00345A58 /* BibFieldTag.h in Headers */,
 				AABDC20722DAC10500345A58 /* BibDirectoryEntry.h in Headers */,
 				AA59F0D720A9FACF00D41982 /* Bibliotek.h in Headers */,
+				AA99BAF62301E4370055C078 /* BibHasher.h in Headers */,
 				AABDC20022DAB2FD00345A58 /* BibLeader.h in Headers */,
 				AA51EA8E211AAAEB00BF28BE /* BibConnectionOptions+Private.h in Headers */,
 				AABDC21322DACDBC00345A58 /* BibContentIndicatorList.h in Headers */,
@@ -588,6 +595,7 @@
 				AA51EA92211AB79A00BF28BE /* BibConnectionEndpoint.m in Sources */,
 				AAAA429F20BB0E3600BDB52B /* BibConstants.m in Sources */,
 				AA51EA98211AC9DF00BF28BE /* BibConnectionOptions.swift in Sources */,
+				AA99BAF72301E4370055C078 /* BibHasher.m in Sources */,
 				AAA4E00522EBFF670003AF7B /* Subfield.swift in Sources */,
 				AABDC21222DACDBC00345A58 /* BibContentIndicatorList.m in Sources */,
 				AAA4E01922ED719F0003AF7B /* Metadata.swift in Sources */,

--- a/Bibliotek/Foundation/BibHasher.h
+++ b/Bibliotek/Foundation/BibHasher.h
@@ -1,0 +1,82 @@
+//
+//  BibHasher.h
+//  Bibliotek
+//
+//  Created by Steve Brunwasser on 8/12/19.
+//  Copyright © 2019 Steve Brunwasser. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class BibHasher;
+@protocol BibHashable;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// An object that encapsulates a hashing algorithm.
+@interface BibHasher : NSObject
+
+/// Update \c hash to include the given value.
+/// \param hash An integer value that should be included in the hash value.
+- (void)combineWithHash:(NSUInteger)hash;
+
+/// Update \c hash to include the hash value of the given object.
+/// \param object The object that should be included in the hash value.
+///
+/// If \c object conforms to the \c BibHashable protocol, \c -hashWithHasher: will be called.
+/// Otherwise, the value returned from its \c -hash method will be combined with this hasher.
+- (void)combineWithObject:(id)object;
+
+/// Update \c hash to include the given hashable object.
+/// \param hashable The receiver of the \c -hashWithHasher: method.
+- (void)combineWithHashable:(id<BibHashable>)hashable;
+
+/// An indexable value that can be used to represent an object.
+@property (nonatomic, readonly) NSUInteger hash;
+
+@end
+
+#pragma mark - Hashable Protocol
+
+/// An object whose hash value can be calculated with any arbitrary hashing algorithm.
+///
+/// Implementers of this protocol should override \c -hash to use the default \c BibHasher object.
+///
+/// \code
+/// - (NSUInteger)hash {
+///     BibHasher *hasher = [BibHasher new];
+///     [hasher combineWithHashable:self];
+///     return [hasher hash];
+/// }
+/// \endcode
+@protocol BibHashable
+
+/// Use the given \c BibHasher object to calculate a hash value.
+/// \param hasher The \c BibHasher object.
+- (void)hashWithHasher:(BibHasher *)hasher;
+
+@end
+
+#pragma mark - Nullable Equality
+
+/// Determine if two nullable objects are equal.
+/// \param receiver The receiver of the \c -isEqual: method.
+/// \param object The object passed into the receiver's \c -isEqual: method.
+/// \returns \c YES when both objects are \c nil or the return value from the receiver's \c -isEqual: method.
+///
+/// \c -isEqual: will retrun \c NO when both \c receiver and \c object are \c nil
+/// even though they are equivalent. This function first checks for the case where
+/// both objects are \c nil before using \c -isEqual: to account for this case.
+extern BOOL BibNullableObjectEqual(id _Nullable receiver, id _Nullable object);
+
+/// Determine if two nullable strings are equal.
+/// \param receiver The receiver of the \c -isEqual: method.
+/// \param string The string passed into the receiver's \c -isEqual: method.
+/// \returns \c YES when both strings are \c nil or the return value from the receiver's \c -isEquaToString: method.
+///
+/// \c -isEqualToString: will retrun \c NO when both \c receiver and \c string are \c nil
+/// even though they are equivalent. This function first checks for the case where both
+/// strings are \c nil before using \c -isEqualToString: to account for this case.
+extern BOOL BibNullableStringEqual(NSString *_Nullable receiver, NSString *_Nullable string);
+
+NS_ASSUME_NONNULL_END

--- a/Bibliotek/Foundation/BibHasher.m
+++ b/Bibliotek/Foundation/BibHasher.m
@@ -1,0 +1,48 @@
+//
+//  BibHasher.m
+//  Bibliotek
+//
+//  Created by Steve Brunwasser on 8/12/19.
+//  Copyright © 2019 Steve Brunwasser. All rights reserved.
+//
+
+#import "BibHasher.h"
+
+static NSUInteger const kUIntegerBitCount = CHAR_BIT * sizeof(NSUInteger);
+
+@implementation BibHasher {
+    NSUInteger _hash;
+    NSUInteger _count;
+}
+
+@synthesize hash = _hash;
+
+- (void)combineWithHash:(NSUInteger)hash {
+    NSUInteger const rotation = (_count) ? (kUIntegerBitCount % _count) : 0;
+    _hash ^= (_hash << rotation) | (_hash >> (kUIntegerBitCount - rotation));
+    _count += 1;
+}
+
+- (void)combineWithObject:(id)object {
+    if ([object conformsToProtocol:@protocol(BibHashable)] && [object respondsToSelector:@selector(hashWithHasher:)]) {
+        [(id<BibHashable>)object hashWithHasher:self];
+    } else {
+        [self combineWithHash:[object hash]];
+    }
+}
+
+- (void)combineWithHashable:(id<BibHashable>)hashable {
+    [hashable hashWithHasher:self];
+}
+
+@end
+
+#pragma mark - Nullable Equality
+
+BOOL BibNullableObjectEqual(id receiver, id object) {
+    return (receiver == object) || (receiver && object && [receiver isEqual:object]);
+}
+
+BOOL BibNullableStringEqual(NSString *receiver, NSString *string) {
+    return (receiver == string) || (receiver && string  && [receiver isEqualToString:string]);
+}

--- a/Bibliotek/Record/BibControlField.m
+++ b/Bibliotek/Record/BibControlField.m
@@ -8,6 +8,7 @@
 
 #import "BibControlField.h"
 #import "BibFieldTag.h"
+#import "BibHasher.h"
 
 @implementation BibControlField {
 @protected
@@ -69,7 +70,10 @@
 }
 
 - (NSUInteger)hash {
-    return [[self tag] hash] ^ [[self value] hash];
+    BibHasher *const hasher = [BibHasher new];
+    [hasher combineWithObject:[self tag]];
+    [hasher combineWithObject:[self value]];
+    return [hasher hash];
 }
 
 @end

--- a/Bibliotek/Record/BibDirectoryEntry.m
+++ b/Bibliotek/Record/BibDirectoryEntry.m
@@ -8,6 +8,7 @@
 
 #import "BibDirectoryEntry.h"
 #import "BibFieldTag.h"
+#import "BibHasher.h"
 
 @implementation BibDirectoryEntry
 
@@ -47,7 +48,11 @@
 
 - (NSUInteger)hash {
     NSRange const range = [self range];
-    return [[self tag] hash] ^ range.location ^ range.length;
+    BibHasher *const hasher = [BibHasher new];
+    [hasher combineWithObject:[self tag]];
+    [hasher combineWithHash:range.location];
+    [hasher combineWithHash:range.length];
+    return [hasher hash];
 }
 
 @end

--- a/Bibliotek/Record/BibRecord.m
+++ b/Bibliotek/Record/BibRecord.m
@@ -10,6 +10,7 @@
 #import "BibRecordKind.h"
 #import "BibControlField.h"
 #import "BibContentField.h"
+#import "BibHasher.h"
 
 @implementation BibRecord {
 @protected
@@ -104,11 +105,13 @@
 }
 
 - (NSUInteger)hash {
-    return [[self kind] hash]
-         ^ ([self status] << 16)
-         ^ [[self metadata] hash]
-         ^ [[self controlFields] hash]
-         ^ [[self contentFields] hash];
+    BibHasher *const hasher = [BibHasher new];
+    [hasher combineWithObject:[self kind]];
+    [hasher combineWithHash:[self status]];
+    [hasher combineWithObject:[self metadata]];
+    [hasher combineWithObject:[self controlFields]];
+    [hasher combineWithObject:[self contentFields]];
+    return [hasher hash];
 }
 
 @end

--- a/Bibliotek/Record/ContentField/BibContentField.m
+++ b/Bibliotek/Record/ContentField/BibContentField.m
@@ -10,6 +10,7 @@
 #import "BibSubfield.h"
 #import "BibContentIndicatorList.h"
 #import "BibFieldTag.h"
+#import "BibHasher.h"
 
 @implementation BibContentField {
 @protected
@@ -74,7 +75,10 @@
 }
 
 - (NSUInteger)hash {
-    return [[self indicators] hash] ^ [[self subfields] hash];
+    BibHasher *const hasher = [BibHasher new];
+    [hasher combineWithObject:[self indicators]];
+    [hasher combineWithObject:[self subfields]];
+    return [hasher hash];
 }
 
 @end

--- a/Bibliotek/Record/ContentField/BibSubfield.m
+++ b/Bibliotek/Record/ContentField/BibSubfield.m
@@ -7,6 +7,7 @@
 //
 
 #import "BibSubfield.h"
+#import "BibHasher.h"
 
 @implementation BibSubfield {
 @protected
@@ -63,7 +64,10 @@
 }
 
 - (NSUInteger)hash {
-    return [[self code] hash] ^ [[self content] hash];
+    BibHasher *const hasher = [BibHasher new];
+    [hasher combineWithObject:[self code]];
+    [hasher combineWithObject:[self content]];
+    return [hasher hash];
 }
 
 @end


### PR DESCRIPTION
`BibHasher` encapsulates a "good enough" hashing algorithm that can be reused in more complicated `-hash` implementations.