### PR TITLE
Create BibRecordField to simplify access to control and data fields

### DIFF
--- a/Bibliotek.xcodeproj/project.pbxproj
+++ b/Bibliotek.xcodeproj/project.pbxproj
@@ -33,6 +33,10 @@
 		AA59055320AA43DD00D41982 /* BibConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = AA59055120AA43DD00D41982 /* BibConnection.m */; };
 		AA59056820AB419C00D41982 /* BibConnection+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AA59056720AB419900D41982 /* BibConnection+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AA59F0D720A9FACF00D41982 /* Bibliotek.h in Headers */ = {isa = PBXBuildFile; fileRef = AA59F0D520A9FACF00D41982 /* Bibliotek.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA67784224843F1300997B29 /* BibRecordField.h in Headers */ = {isa = PBXBuildFile; fileRef = AA67784024843F1300997B29 /* BibRecordField.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA67784324843F1300997B29 /* BibRecordField.m in Sources */ = {isa = PBXBuildFile; fileRef = AA67784124843F1300997B29 /* BibRecordField.m */; };
+		AA677858248D63C900997B29 /* BibFieldIndicator.h in Headers */ = {isa = PBXBuildFile; fileRef = AA677856248D63C900997B29 /* BibFieldIndicator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA677859248D63C900997B29 /* BibFieldIndicator.m in Sources */ = {isa = PBXBuildFile; fileRef = AA677857248D63C900997B29 /* BibFieldIndicator.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		AA6D18D620B5B6CC00603E61 /* BibFetchRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = AA6D18D420B5B6CC00603E61 /* BibFetchRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA6D18D720B5B6CC00603E61 /* BibFetchRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = AA6D18D520B5B6CC00603E61 /* BibFetchRequest.m */; };
 		AA6D18D920B5B9FC00603E61 /* BibFetchRequest+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AA6D18D820B5B9FC00603E61 /* BibFetchRequest+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -172,6 +176,10 @@
 		AA59F0D220A9FACF00D41982 /* Bibliotek.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bibliotek.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA59F0D520A9FACF00D41982 /* Bibliotek.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Bibliotek.h; sourceTree = "<group>"; };
 		AA59F0D620A9FACF00D41982 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AA67784024843F1300997B29 /* BibRecordField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BibRecordField.h; sourceTree = "<group>"; };
+		AA67784124843F1300997B29 /* BibRecordField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BibRecordField.m; sourceTree = "<group>"; };
+		AA677856248D63C900997B29 /* BibFieldIndicator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BibFieldIndicator.h; sourceTree = "<group>"; };
+		AA677857248D63C900997B29 /* BibFieldIndicator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BibFieldIndicator.m; sourceTree = "<group>"; };
 		AA6D18D420B5B6CC00603E61 /* BibFetchRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BibFetchRequest.h; sourceTree = "<group>"; };
 		AA6D18D520B5B6CC00603E61 /* BibFetchRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BibFetchRequest.m; sourceTree = "<group>"; };
 		AA6D18D820B5B9FC00603E61 /* BibFetchRequest+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BibFetchRequest+Private.h"; sourceTree = "<group>"; };
@@ -354,6 +362,17 @@
 			path = Bibliotek;
 			sourceTree = "<group>";
 		};
+		AA67783F24843EF500997B29 /* RecordField */ = {
+			isa = PBXGroup;
+			children = (
+				AA67784024843F1300997B29 /* BibRecordField.h */,
+				AA67784124843F1300997B29 /* BibRecordField.m */,
+				AA677856248D63C900997B29 /* BibFieldIndicator.h */,
+				AA677857248D63C900997B29 /* BibFieldIndicator.m */,
+			);
+			path = RecordField;
+			sourceTree = "<group>";
+		};
 		AAA4E02022EE32CF0003AF7B /* ContentField */ = {
 			isa = PBXGroup;
 			children = (
@@ -472,6 +491,7 @@
 				AABDC1FD22DAB2FD00345A58 /* BibLeader.m */,
 				AABDC20522DAC10500345A58 /* BibDirectoryEntry.h */,
 				AABDC20422DAC10500345A58 /* BibDirectoryEntry.m */,
+				AA67783F24843EF500997B29 /* RecordField */,
 				AAA4E02322EE334C0003AF7B /* Primitives */,
 				AABDC20C22DAC99F00345A58 /* BibControlField.h */,
 				AABDC20D22DAC99F00345A58 /* BibControlField.m */,
@@ -514,6 +534,8 @@
 				AA59056820AB419C00D41982 /* BibConnection+Private.h in Headers */,
 				AABDC20E22DAC99F00345A58 /* BibControlField.h in Headers */,
 				AABDC21A22DAE05200345A58 /* BibSubfield.h in Headers */,
+				AA67784224843F1300997B29 /* BibRecordField.h in Headers */,
+				AA677858248D63C900997B29 /* BibFieldIndicator.h in Headers */,
 				AA6D18D620B5B6CC00603E61 /* BibFetchRequest.h in Headers */,
 				AAA4E01722ED66A70003AF7B /* BibMetadata+Internal.h in Headers */,
 				AAAA42A220BB156100BDB52B /* BibRecordList.h in Headers */,
@@ -673,6 +695,7 @@
 				AAA4E00B22EC119A0003AF7B /* Record.swift in Sources */,
 				AAAFD9A5247CDAB200D2D1F0 /* BibLCCallNumber.swift in Sources */,
 				AAB7865F24566E2B0018A833 /* BibMARCSerialization.swift in Sources */,
+				AA677859248D63C900997B29 /* BibFieldIndicator.m in Sources */,
 				AAAFD996247B65EC00D2D1F0 /* BibCharacterConversion.m in Sources */,
 				AA258AFD21FE3C2A00CDF88E /* NSString+BibCharacterSetValidation.m in Sources */,
 				AA51EA8C211AA98B00BF28BE /* BibConnectionOptions.m in Sources */,
@@ -702,6 +725,7 @@
 				AAAFD99C247C3A6300D2D1F0 /* BibLCCallNumber.m in Sources */,
 				AAA4E00922EC0C730003AF7B /* ContentField.swift in Sources */,
 				AAAA42A320BB156100BDB52B /* BibRecordList.m in Sources */,
+				AA67784324843F1300997B29 /* BibRecordField.m in Sources */,
 				AABDC20A22DAC17A00345A58 /* BibFieldTag.m in Sources */,
 				AABDC21B22DAE05200345A58 /* BibSubfield.m in Sources */,
 				AA59055320AA43DD00D41982 /* BibConnection.m in Sources */,

--- a/Bibliotek.xcodeproj/project.pbxproj
+++ b/Bibliotek.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		AA59055320AA43DD00D41982 /* BibConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = AA59055120AA43DD00D41982 /* BibConnection.m */; };
 		AA59056820AB419C00D41982 /* BibConnection+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = AA59056720AB419900D41982 /* BibConnection+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AA59F0D720A9FACF00D41982 /* Bibliotek.h in Headers */ = {isa = PBXBuildFile; fileRef = AA59F0D520A9FACF00D41982 /* Bibliotek.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AA619E17249ECD7500BB3A25 /* RecordField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA619E16249ECD7500BB3A25 /* RecordField.swift */; };
+		AA619E19249ECDFB00BB3A25 /* FieldIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA619E18249ECDFB00BB3A25 /* FieldIndicator.swift */; };
 		AA67784224843F1300997B29 /* BibRecordField.h in Headers */ = {isa = PBXBuildFile; fileRef = AA67784024843F1300997B29 /* BibRecordField.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA67784324843F1300997B29 /* BibRecordField.m in Sources */ = {isa = PBXBuildFile; fileRef = AA67784124843F1300997B29 /* BibRecordField.m */; };
 		AA677858248D63C900997B29 /* BibFieldIndicator.h in Headers */ = {isa = PBXBuildFile; fileRef = AA677856248D63C900997B29 /* BibFieldIndicator.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -176,6 +178,8 @@
 		AA59F0D220A9FACF00D41982 /* Bibliotek.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bibliotek.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA59F0D520A9FACF00D41982 /* Bibliotek.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Bibliotek.h; sourceTree = "<group>"; };
 		AA59F0D620A9FACF00D41982 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AA619E16249ECD7500BB3A25 /* RecordField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordField.swift; sourceTree = "<group>"; };
+		AA619E18249ECDFB00BB3A25 /* FieldIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldIndicator.swift; sourceTree = "<group>"; };
 		AA67784024843F1300997B29 /* BibRecordField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BibRecordField.h; sourceTree = "<group>"; };
 		AA67784124843F1300997B29 /* BibRecordField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BibRecordField.m; sourceTree = "<group>"; };
 		AA677856248D63C900997B29 /* BibFieldIndicator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BibFieldIndicator.h; sourceTree = "<group>"; };
@@ -367,8 +371,10 @@
 			children = (
 				AA67784024843F1300997B29 /* BibRecordField.h */,
 				AA67784124843F1300997B29 /* BibRecordField.m */,
+				AA619E16249ECD7500BB3A25 /* RecordField.swift */,
 				AA677856248D63C900997B29 /* BibFieldIndicator.h */,
 				AA677857248D63C900997B29 /* BibFieldIndicator.m */,
+				AA619E18249ECDFB00BB3A25 /* FieldIndicator.swift */,
 			);
 			path = RecordField;
 			sourceTree = "<group>";
@@ -729,6 +735,8 @@
 				AABDC20A22DAC17A00345A58 /* BibFieldTag.m in Sources */,
 				AABDC21B22DAE05200345A58 /* BibSubfield.m in Sources */,
 				AA59055320AA43DD00D41982 /* BibConnection.m in Sources */,
+				AA619E17249ECD7500BB3A25 /* RecordField.swift in Sources */,
+				AA619E19249ECDFB00BB3A25 /* FieldIndicator.swift in Sources */,
 				AAA4E00322EBFBA40003AF7B /* ControlField.swift in Sources */,
 				AABDC20622DAC10500345A58 /* BibDirectoryEntry.m in Sources */,
 				AABDC21F22DAE32D00345A58 /* BibContentField.m in Sources */,

--- a/Bibliotek/Bibliotek.h
+++ b/Bibliotek/Bibliotek.h
@@ -22,6 +22,8 @@ FOUNDATION_EXPORT const unsigned char BibliotekVersionString[];
 #import <Bibliotek/BibRecordList.h>
 
 #import <Bibliotek/BibRecord.h>
+#import <Bibliotek/BibRecordField.h>
+#import <Bibliotek/BibFieldIndicator.h>
 #import <Bibliotek/BibControlField.h>
 #import <Bibliotek/BibContentField.h>
 #import <Bibliotek/BibContentIndicatorList.h>

--- a/Bibliotek/Record/BibControlField.h
+++ b/Bibliotek/Record/BibControlField.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Information about Classification control fields can be found in the Library of Congress's documentation:
 /// https://www.loc.gov/marc/classification/cd00x.html
+DEPRECATED_MSG_ATTRIBUTE("replaced with 'BibRecordField'")
 @interface BibControlField : NSObject <BibField>
 
 /// A value indicating the semantic purpose of the control field.
@@ -43,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// \param tag The field tag indicating the semantic purpose of the control field.
 /// \param value The information contained within the control field.
 /// \returns A control field with the given tag and value.
-+ (instancetype)controlFieldWithTag:(BibFieldTag *)tag value:(NSString *)value NS_SWIFT_UNAVAILABLE("Use init(tag:value:");
++ (instancetype)controlFieldWithTag:(BibFieldTag *)tag value:(NSString *)value NS_SWIFT_UNAVAILABLE("use 'init(tag:value:)'");
 
 @end
 
@@ -66,6 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Mutable
 
+DEPRECATED_MSG_ATTRIBUTE("replaced with 'BibMutableRecordField'")
 @interface BibMutableControlField : BibControlField
 
 /// A value indicating the semantic purpose of the control field.

--- a/Bibliotek/Record/BibControlField.m
+++ b/Bibliotek/Record/BibControlField.m
@@ -12,6 +12,8 @@
 
 #import "Bibliotek+Internal.h"
 
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
 @implementation BibControlField {
 @protected
     BibFieldTag *_tag;

--- a/Bibliotek/Record/BibRecord.h
+++ b/Bibliotek/Record/BibRecord.h
@@ -146,14 +146,42 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface BibRecord (FieldAccess)
 
+/// Get the field at the given index.
+/// \param index The index of the record field to access.
+/// \returns The data field or control field located at the given index.
 - (BibRecordField *)fieldAtIndex:(NSUInteger)index NS_SWIFT_NAME(field(at:));
+
+/// Test to see if the record contains a field with the given tag.
+/// \param fieldTag If this record has a field with this value, \c YES is returned.
+/// \returns \c YES if at least one record field is marked with the given tag.
 - (BOOL)containsFieldWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(containsField(with:));
+
+/// Get the index of the first record field with the given tag.
+/// \param fieldTag The field tag marking the data field or control field to access.
+/// \returns The index of the first record with the given tag. If no such field exists, \c NSNotFound is returned.
 - (NSUInteger)indexOfFieldWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(indexOfField(with:));
+
+/// Get the first record field with the given tag.
+/// \param fieldTag The field tag marking the data field or control field to access.
+/// \returns The first record with the given tag. If no such field exists, \c nil is returned.
 - (nullable BibRecordField *)fieldWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(field(with:));
 
+/// Get the record field referenced by the given index path.
+/// \param indexPath The index path value pointing to the field or one of its subfields.
+/// \returns The record field referenced by the index path.
+///          If the index path points to a subfield, its field is returned.
 - (BibRecordField *)fieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(field(at:));
+
+/// Get the subfield referenced by the given index path.
+/// \param indexPath The index path value pointing to a specific subfield value.
+/// \returns The subfield object referenced byt the index path.
+/// \throws \c NSRangeException when given an index path that points to a field instead of its subfield,
+///         or if the index path points into a control field instead of a data field.
 - (BibSubfield *)subfieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(subfield(at:));
 
+/// Get a string representation of the value stored at the given index path.
+/// \param indexPath The index path of a control field, data field, or subfield.
+/// \returns A string representation of the data contained within the referenced control field, data field, or subfield.
 - (NSString *)contentAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(content(at:));
 
 @end

--- a/Bibliotek/Record/BibRecord.h
+++ b/Bibliotek/Record/BibRecord.h
@@ -145,8 +145,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable BibControlField *)controlFieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(controlField(at:)) DEPRECATED_MSG_ATTRIBUTE("Use -fieldAtIndexPath:");
 - (nullable BibContentField *)contentFieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(contentField(at:)) DEPRECATED_MSG_ATTRIBUTE("Use -fieldAtIndexPath:");
 
-- (nullable BibRecordField *)fieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(field(at:));
-- (nullable BibSubfield *)subfieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(subfield(at:));
+- (BibRecordField *)fieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(field(at:));
+- (BibSubfield *)subfieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(subfield(at:));
 
 - (NSString *)contentAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(content(at:));
 

--- a/Bibliotek/Record/BibRecord.h
+++ b/Bibliotek/Record/BibRecord.h
@@ -52,10 +52,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly) BibMetadata *metadata;
 
 /// An ordered list of fields containing information and metadata about how a record's content should be processed.
-@property (nonatomic, copy, readonly) NSArray<BibControlField *> *controlFields DEPRECATED_MSG_ATTRIBUTE("Use -fields");
+@property (nonatomic, copy, readonly) NSArray<BibControlField *> *controlFields DEPRECATED_MSG_ATTRIBUTE("replaced with '-fields'");
 
 /// An ordered list of fields containing information and metadata about the item represented by a record.
-@property (nonatomic, copy, readonly) NSArray<BibContentField *> *contentFields DEPRECATED_MSG_ATTRIBUTE("Use -fields");
+@property (nonatomic, copy, readonly) NSArray<BibContentField *> *contentFields DEPRECATED_MSG_ATTRIBUTE("replaced with '-fields'");
 
 /// An ordered list of fields containing information and metadata about the record and its represented item.
 @property (nonatomic, copy, readonly) NSArray<BibRecordField *> *fields;
@@ -72,7 +72,8 @@ NS_ASSUME_NONNULL_BEGIN
                       status:(BibRecordStatus)status
                     metadata:(BibMetadata *)metadata
                controlFields:(NSArray<BibControlField *> *)controlFields
-               contentFields:(NSArray<BibContentField *> *)contentFields;
+               contentFields:(NSArray<BibContentField *> *)contentFields
+    DEPRECATED_MSG_ATTRIBUTE("replaced with '-initWithKind:status:metadata:fields:'");
 
 /// Create a MARC 21 record with the given data.
 ///
@@ -81,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// \param metadata A set of implementation-defined bytes.
 /// \param fields An ordered list of control fields and data fields describing the record and its represented item.
 /// \returns Returns a valid MARC 21 record for some item or entity described by the given fields.
-- (instancetype)initWithKind:(BibRecordKind *)kind
+- (instancetype)initWithKind:(nullable BibRecordKind *)kind
                       status:(BibRecordStatus)status
                     metadata:(BibMetadata *)metadata
                       fields:(NSArray<BibRecordField *> *)fields NS_DESIGNATED_INITIALIZER;
@@ -94,7 +95,8 @@ NS_ASSUME_NONNULL_BEGIN
                       metadata:(BibMetadata *)metadata
                  controlFields:(NSArray<BibControlField *> *)controlFields
                  contentFields:(NSArray<BibContentField *> *)contentFields
-    NS_SWIFT_UNAVAILABLE("Use init(kind:status:metadata:controlFields:contentFields:");
+    NS_SWIFT_UNAVAILABLE("use 'init(kind:status:metadata:controlFields:contentFields:)'")
+    DEPRECATED_MSG_ATTRIBUTE("replaced with '+recordWithKind:status:metadata:fields:'");
 
 /// Create a MARC 21 record containing data from the given leader, control fields, and data fields.
 ///
@@ -103,7 +105,7 @@ NS_ASSUME_NONNULL_BEGIN
                         status:(BibRecordStatus)status
                       metadata:(BibMetadata *)metadata
                         fields:(NSArray<BibRecordField *> *)controlFields
-    NS_SWIFT_UNAVAILABLE("Use init(kind:status:metadata:fields:");
+    NS_SWIFT_UNAVAILABLE("use 'init(kind:status:metadata:fields:)'");
 
 
 @end
@@ -137,8 +139,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<BibControlField *> *)controlFieldsWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(controlFields(with:)) DEPRECATED_ATTRIBUTE;
 - (NSArray<BibContentField *> *)contentFieldsWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(contentFields(with:)) DEPRECATED_ATTRIBUTE;
 
-- (nullable BibControlField *)controlFieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(controlField(at:)) DEPRECATED_MSG_ATTRIBUTE("Use -fieldAtIndexPath:");
-- (nullable BibContentField *)contentFieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(contentField(at:)) DEPRECATED_MSG_ATTRIBUTE("Use -fieldAtIndexPath:");
+- (nullable BibControlField *)controlFieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(controlField(at:)) DEPRECATED_MSG_ATTRIBUTE("replaced with '-fieldAtIndexPath:'");
+- (nullable BibContentField *)contentFieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(contentField(at:)) DEPRECATED_MSG_ATTRIBUTE("replaced with '-fieldAtIndexPath:'");
 
 @end
 
@@ -195,9 +197,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy, readwrite) BibMetadata *metadata;
 
-@property (nonatomic, copy, readwrite) NSArray<BibControlField *> *controlFields DEPRECATED_MSG_ATTRIBUTE("Use -fields");
+@property (nonatomic, copy, readwrite) NSArray<BibControlField *> *controlFields DEPRECATED_MSG_ATTRIBUTE("replaced with '-fields'");
 
-@property (nonatomic, copy, readwrite) NSArray<BibContentField *> *contentFields DEPRECATED_MSG_ATTRIBUTE("Use -fields");
+@property (nonatomic, copy, readwrite) NSArray<BibContentField *> *contentFields DEPRECATED_MSG_ATTRIBUTE("replaced with '-fields'");
 
 /// An ordered list of fields containing information and metadata about the record and its represented item.
 @property (nonatomic, copy, readwrite) NSArray<BibRecordField *> *fields;

--- a/Bibliotek/Record/BibRecord.h
+++ b/Bibliotek/Record/BibRecord.h
@@ -137,6 +137,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<BibControlField *> *)controlFieldsWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(controlFields(with:)) DEPRECATED_ATTRIBUTE;
 - (NSArray<BibContentField *> *)contentFieldsWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(contentFields(with:)) DEPRECATED_ATTRIBUTE;
 
+- (BibRecordField *)fieldAtIndex:(NSUInteger)index NS_SWIFT_NAME(field(at:));
+- (BOOL)containsFieldWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(containsField(with:));
+- (NSUInteger)indexOfFieldWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(indexOfField(with:));
+- (nullable BibRecordField *)fieldWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(field(with:));
+
+- (NSArray<BibRecordField *> *)fieldsWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(fields(with:));
+
 - (NSArray<NSIndexPath *> *)indexPathsForFieldTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(indexPaths(for:));
 - (NSArray<NSIndexPath *> *)indexPathsForFieldTag:(BibFieldTag *)fieldTag subfieldCode:(BibSubfieldCode)subfieldCode
     NS_SWIFT_NAME(indexPaths(for:code:));

--- a/Bibliotek/Record/BibRecord.h
+++ b/Bibliotek/Record/BibRecord.h
@@ -126,7 +126,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Field Access
 
-@interface BibRecord (FieldAccess)
+@interface BibRecord (DeprecatedFieldAccess)
 
 - (BibFieldEnumerator<BibControlField *> *)controlFieldEnumerator DEPRECATED_ATTRIBUTE;
 - (BibFieldEnumerator<BibContentField *> *)contentFieldEnumerator DEPRECATED_ATTRIBUTE;
@@ -137,25 +137,33 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<BibControlField *> *)controlFieldsWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(controlFields(with:)) DEPRECATED_ATTRIBUTE;
 - (NSArray<BibContentField *> *)contentFieldsWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(contentFields(with:)) DEPRECATED_ATTRIBUTE;
 
+- (nullable BibControlField *)controlFieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(controlField(at:)) DEPRECATED_MSG_ATTRIBUTE("Use -fieldAtIndexPath:");
+- (nullable BibContentField *)contentFieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(contentField(at:)) DEPRECATED_MSG_ATTRIBUTE("Use -fieldAtIndexPath:");
+
+@end
+
+@interface BibRecord (FieldAccess)
+
 - (BibRecordField *)fieldAtIndex:(NSUInteger)index NS_SWIFT_NAME(field(at:));
 - (BOOL)containsFieldWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(containsField(with:));
 - (NSUInteger)indexOfFieldWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(indexOfField(with:));
 - (nullable BibRecordField *)fieldWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(field(with:));
 
-- (NSArray<BibRecordField *> *)fieldsWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(fields(with:));
+- (BibRecordField *)fieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(field(at:));
+- (BibSubfield *)subfieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(subfield(at:));
+
+- (NSString *)contentAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(content(at:));
+
+@end
+
+@interface BibRecord (MultipleFieldAccess)
+
+- (NSArray<BibRecordField *> *)allFieldsWithTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(fields(with:));
 
 - (NSArray<NSIndexPath *> *)indexPathsForFieldTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(indexPaths(for:));
 - (NSArray<NSIndexPath *> *)indexPathsForFieldTag:(BibFieldTag *)fieldTag subfieldCode:(BibSubfieldCode)subfieldCode
     NS_SWIFT_NAME(indexPaths(for:code:));
 - (NSArray<NSIndexPath *> *)indexPathsForFieldPath:(BibFieldPath *)fieldPath NS_SWIFT_NAME(indexPaths(for:));
-
-- (nullable BibControlField *)controlFieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(controlField(at:)) DEPRECATED_MSG_ATTRIBUTE("Use -fieldAtIndexPath:");
-- (nullable BibContentField *)contentFieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(contentField(at:)) DEPRECATED_MSG_ATTRIBUTE("Use -fieldAtIndexPath:");
-
-- (BibRecordField *)fieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(field(at:));
-- (BibSubfield *)subfieldAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(subfield(at:));
-
-- (NSString *)contentAtIndexPath:(NSIndexPath *)indexPath NS_SWIFT_NAME(content(at:));
 
 - (NSArray<NSString *> *)contentWithFieldTag:(BibFieldTag *)fieldTag NS_SWIFT_NAME(content(with:));
 - (NSArray<NSString *> *)contentWithFieldTag:(BibFieldTag *)fieldTag subfieldCode:(BibSubfieldCode)subfieldCode

--- a/Bibliotek/Record/BibRecord.m
+++ b/Bibliotek/Record/BibRecord.m
@@ -17,10 +17,10 @@
 
 #import "Bibliotek+Internal.h"
 
-static BibControlField *BibControlFieldFromRecordField(BibRecordField *recordField);
-static BibContentField *BibContentFieldFromRecordField(BibRecordField *recordField);
-static BibRecordField *BibRecordFieldFromControlField(BibControlField *controlField);
-static BibRecordField *BibRecordFieldFromContentField(BibContentField *contentField);
+static BibControlField *BibControlFieldFromRecordField(BibRecordField *recordField) DEPRECATED_ATTRIBUTE;
+static BibContentField *BibContentFieldFromRecordField(BibRecordField *recordField) DEPRECATED_ATTRIBUTE;
+static BibRecordField *BibRecordFieldFromControlField(BibControlField *controlField) DEPRECATED_ATTRIBUTE;
+static BibRecordField *BibRecordFieldFromContentField(BibContentField *contentField) DEPRECATED_ATTRIBUTE;
 
 @implementation BibRecord {
 @protected

--- a/Bibliotek/Record/BibRecord.m
+++ b/Bibliotek/Record/BibRecord.m
@@ -353,7 +353,7 @@ static BibRecordField *BibRecordFieldFromContentField(BibContentField *contentFi
 @dynamic controlFields;
 - (void)setControlFields:(NSArray<BibControlField *> *)fields {
     NSMutableArray *newValue = [NSMutableArray new];
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == YES", BibKeyPath(isDatafield)];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == YES", BibKeyPath(isDataField)];
     for (BibControlField *field in fields) {
         [newValue addObject:BibRecordFieldFromControlField(field)];
     }
@@ -364,7 +364,7 @@ static BibRecordField *BibRecordFieldFromContentField(BibContentField *contentFi
 
 @dynamic contentFields;
 - (void)setContentFields:(NSArray<BibContentField *> *)fields {
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == YES", BibKeyPath(isControlfield)];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == YES", BibKeyPath(isControlField)];
     NSMutableArray *newValue = [[self.fields filteredArrayUsingPredicate:predicate] mutableCopy];
     for (BibContentField *field in fields) {
         [newValue addObject:BibRecordFieldFromContentField(field)];

--- a/Bibliotek/Record/BibRecord.m
+++ b/Bibliotek/Record/BibRecord.m
@@ -203,6 +203,35 @@ static BibRecordField *BibRecordFieldFromContentField(BibContentField *contentFi
     return [[self contentFields] filteredArrayUsingPredicate:predicate];
 }
 
+- (BibRecordField *)fieldAtIndex:(NSUInteger)index {
+    return [self.fields objectAtIndex:index];
+}
+
+- (BOOL)containsFieldWithTag:(BibFieldTag *)fieldTag {
+    return [self indexOfFieldWithTag:fieldTag] != NSNotFound;
+}
+
+- (NSUInteger)indexOfFieldWithTag:(BibFieldTag *)fieldTag {
+    NSArray *const recordFields = self.fields;
+    NSUInteger const count = recordFields.count;
+    for (NSUInteger index = 0; index < count; index += 1) {
+        if ([[[recordFields objectAtIndex:index] fieldTag] isEqualToTag:fieldTag]) {
+            return index;
+        }
+    }
+    return NSNotFound;
+}
+
+- (BibRecordField *)fieldWithTag:(BibFieldTag *)fieldTag {
+    NSUInteger const index = [self indexOfFieldWithTag:fieldTag];
+    return (index == NSNotFound) ? nil : [self fieldAtIndex:index];
+}
+
+- (NSArray<BibRecordField *> *)fieldsWithTag:(BibFieldTag *)fieldTag {
+    NSPredicate *const predicate = [NSPredicate predicateWithFormat:@"%K = %@", BibKey(fieldTag), fieldTag];
+    return [[self fields] filteredArrayUsingPredicate:predicate];
+}
+
 - (NSArray<NSIndexPath *> *)indexPathsForFieldTag:(BibFieldTag *)fieldTag {
     NSMutableArray *const indexPaths = [NSMutableArray new];
     NSArray *const fields = [self fields];
@@ -241,7 +270,7 @@ static BibRecordField *BibRecordFieldFromContentField(BibContentField *contentFi
     if ([fieldPath isSubfieldPath]) {
         return [self indexPathsForFieldTag:[fieldPath fieldTag] subfieldCode:[fieldPath subfieldCode]];
     }
-    if ([fieldPath isControlFieldPath] || [fieldPath isContentFieldPath]) {
+    if ([fieldPath isControlFieldPath] || [fieldPath isDataFieldPath]) {
         return [self indexPathsForFieldTag:[fieldPath fieldTag]];
     }
     return [NSArray array];

--- a/Bibliotek/Record/BibRecord.m
+++ b/Bibliotek/Record/BibRecord.m
@@ -7,50 +7,72 @@
 //
 
 #import "BibRecord.h"
+#import "BibRecordField.h"
 #import "BibRecordKind.h"
 #import "BibControlField.h"
 #import "BibContentField.h"
 #import "BibFieldTag.h"
 #import "BibHasher.h"
+#import "BibFieldIndicator.h"
 
 #import "Bibliotek+Internal.h"
+
+static BibControlField *BibControlFieldFromRecordField(BibRecordField *recordField);
+static BibContentField *BibContentFieldFromRecordField(BibRecordField *recordField);
+static BibRecordField *BibRecordFieldFromControlField(BibControlField *controlField);
+static BibRecordField *BibRecordFieldFromContentField(BibContentField *contentField);
 
 @implementation BibRecord {
 @protected
     BibRecordKind *_kind;
     BibRecordStatus _status;
     BibMetadata *_metadata;
-    NSArray<BibControlField *> *_controlFields;
-    NSArray<BibContentField *> *_contentFields;
+    NSArray<BibRecordField *> *_fields;
 }
 
 @synthesize kind = _kind;
 @synthesize status = _status;
 @synthesize metadata = _metadata;
-@synthesize controlFields = _controlFields;
-@synthesize contentFields = _contentFields;
+@synthesize fields = _fields;
 
 - (instancetype)initWithKind:(BibRecordKind *)kind
                       status:(BibRecordStatus)status
                     metadata:(BibMetadata *)metadata
                controlFields:(NSArray<BibControlField *> *)controlFields
                contentFields:(NSArray<BibContentField *> *)contentFields {
-    if (self = [super init]) {
-        _kind = kind;
-        _status = status;
-        _metadata = [metadata copy];
-        _controlFields = [controlFields copy];
-        _contentFields = [contentFields copy];
+    NSMutableArray *const recordFields = [NSMutableArray new];
+    for (BibControlField *field in controlFields) {
+        [recordFields addObject:[[BibRecordField alloc] initWithFieldTag:field.tag controlValue:field.value]];
     }
-    return self;
+    for (BibContentField *field in contentFields) {
+        BibFieldIndicator *const first = [BibFieldIndicator indicatorWithRawValue:field.indicators.firstIndicator];
+        BibFieldIndicator *const second = [BibFieldIndicator indicatorWithRawValue:field.indicators.secondIndicator];
+        [recordFields addObject:[[BibRecordField alloc] initWithFieldTag:field.tag
+                                                          firstIndicator:first
+                                                         secondIndicator:second
+                                                               subfields:field.subfields]];
+    }
+    return [self initWithKind:kind status:status metadata:metadata fields:recordFields];
 }
 
 - (instancetype)init {
     return [self initWithKind:nil
                        status:BibRecordStatusNew
                      metadata:[BibMetadata new]
-                controlFields:[NSArray array]
-                contentFields:[NSArray array]];
+                       fields:[NSArray new]];
+}
+
+- (instancetype)initWithKind:(BibRecordKind *)kind
+                      status:(BibRecordStatus)status
+                    metadata:(BibMetadata *)metadata
+                      fields:(NSArray<BibRecordField *> *)fields {
+    if (self = [super init]) {
+        _kind = kind;
+        _status = status;
+        _metadata = [metadata copy];
+        _fields = [fields copy];
+    }
+    return self;
 }
 
 + (instancetype)recordWithKind:(BibRecordKind *)kind
@@ -65,16 +87,45 @@
                         contentFields:contentFields];
 }
 
++ (instancetype)recordWithKind:(BibRecordKind *)kind
+                        status:(BibRecordStatus)status
+                      metadata:(BibMetadata *)metadata
+                        fields:(NSArray<BibRecordField *> *)fields {
+    return [[self alloc] initWithKind:kind status:status metadata:metadata fields:fields];
+}
+
 - (NSString *)description {
-    NSArray *const fields = [[self controlFields] arrayByAddingObjectsFromArray:(id)[self contentFields]];
-    return [[fields valueForKey:BibKey(debugDescription)] componentsJoinedByString:@"\n"];
+    return [[[self fields] valueForKey:BibKey(debugDescription)] componentsJoinedByString:@"\n"];
 }
 
 + (NSSet *)keyPathsForValuesAffectingDescription {
-    return [NSSet setWithObjects:BibKey(controlFields), BibKey(contentFields),
-                                 BibKeyPath(controlFields, debugDescription),
-                                 BibKeyPath(contentFields, debugDescription), nil];
+    return [NSSet setWithObjects:BibKey(fields), BibKeyPath(fields, debugDescription), nil];
 }
+
+- (NSArray<BibControlField *> *)controlFields {
+    NSMutableArray *const controlFields = [NSMutableArray new];
+    NSEnumerator *const enumerator = [[self fields] objectEnumerator];
+    BibRecordField *field = [enumerator nextObject];
+    for (; field != nil && field.isControlField; field = [enumerator nextObject]) {
+        [controlFields addObject:BibControlFieldFromRecordField(field)];
+    }
+    return [controlFields copy];
+}
+
++ (NSSet *)keyPathsForValuesAffectingControlFields { return [NSSet setWithObject:BibKey(fields)]; }
+
+- (NSArray<BibContentField *> *)contentFields {
+    NSMutableArray *const contentFields = [NSMutableArray new];
+    for (BibRecordField *field in [self fields]) {
+        BibContentField *const contentField = BibContentFieldFromRecordField(field);
+        if (contentField != nil) {
+            [contentFields addObject:contentField];
+        }
+    }
+    return [contentFields copy];
+}
+
++ (NSSet *)keyPathsForValuesAffectingContentFields { return [NSSet setWithObject:BibKey(fields)]; }
 
 @end
 
@@ -90,8 +141,7 @@
     return [[BibMutableRecord allocWithZone:zone] initWithKind:[self kind]
                                                         status:[self status]
                                                       metadata:[self metadata]
-                                                 controlFields:[self controlFields]
-                                                 contentFields:[self contentFields]];
+                                                        fields:[self fields]];
 }
 
 @end
@@ -104,8 +154,7 @@
     return [[self kind] isEqualToRecordKind:[record kind]]
         && [self status] == [record status]
         && [[self metadata] isEqualToMetadata:[record metadata]]
-        && [[self controlFields] isEqualToArray:[record controlFields]]
-        && [[self contentFields] isEqualToArray:[record contentFields]];
+        && [[self fields] isEqualToArray:[record fields]];
 }
 
 - (BOOL)isEqual:(id)object {
@@ -118,8 +167,7 @@
     [hasher combineWithObject:[self kind]];
     [hasher combineWithHash:[self status]];
     [hasher combineWithObject:[self metadata]];
-    [hasher combineWithObject:[self controlFields]];
-    [hasher combineWithObject:[self contentFields]];
+    [hasher combineWithObject:[self fields]];
     return [hasher hash];
 }
 
@@ -157,36 +205,33 @@
 
 - (NSArray<NSIndexPath *> *)indexPathsForFieldTag:(BibFieldTag *)fieldTag {
     NSMutableArray *const indexPaths = [NSMutableArray new];
-    if ([fieldTag isControlFieldTag]) {
-        NSArray *const controlFields = [self controlFields];
-        NSUInteger const controlFieldsCount = [controlFields count];
-        for (NSUInteger fieldIndex = 0; fieldIndex < controlFieldsCount; fieldIndex += 1) {
-            BibControlField *const controlField = [controlFields objectAtIndex:fieldIndex];
-            if ([[controlField tag] isEqualToTag:fieldTag]) {
-                [indexPaths addObject:[[NSIndexPath alloc] initWithIndex:fieldIndex]];
-            }
-        }
-    } else {
-        NSArray *const contentFields = [self contentFields];
-        NSUInteger const contnetFiledsCount = [contentFields count];
-        NSUInteger const controlFieldsCount = [[self controlFields] count];
-        for (NSUInteger fieldIndex = 0; fieldIndex < contnetFiledsCount; fieldIndex += 1) {
-            BibContentField *const contentField = [contentFields objectAtIndex:fieldIndex];
-            if ([[contentField tag] isEqualToTag:fieldTag]) {
-                [indexPaths addObject:[[NSIndexPath alloc] initWithIndex:(fieldIndex + controlFieldsCount)]];
-            }
+    NSArray *const fields = [self fields];
+    NSUInteger const count = [fields count];
+    for (NSUInteger index = 0; index < count; index += 1) {
+        BibRecordField *const field = [fields objectAtIndex:index];
+        if ([[field fieldTag] isEqualToTag:fieldTag]) {
+            [indexPaths addObject:[NSIndexPath indexPathWithIndex:index]];
         }
     }
     return [indexPaths copy];
 }
 
 - (NSArray<NSIndexPath *> *)indexPathsForFieldTag:(BibFieldTag *)fieldTag subfieldCode:(BibSubfieldCode)subfieldCode {
+    NSParameterAssert([fieldTag isDataTag]);
     NSMutableArray *const indexPaths = [NSMutableArray new];
-    for (NSIndexPath *path in [self indexPathsForFieldTag:fieldTag]) {
-        BibContentField *const contentField = [self contentFieldAtIndexPath:path];
-        NSIndexSet const *indexes = [contentField indexesOfSubfieldsWithCode:subfieldCode] ?: [NSIndexSet new];
-        for (NSUInteger index = [indexes firstIndex]; index != NSNotFound; index = [indexes indexGreaterThanIndex:index]) {
-            [indexPaths addObject:[path indexPathByAddingIndex:index]];
+    NSArray *const fields = [self fields];
+    NSUInteger const count = [fields count];
+    for (NSUInteger index = 0; index < count; index += 1) {
+        BibRecordField *const field = [fields objectAtIndex:index];
+        if ([[field fieldTag] isEqualToTag:fieldTag]) {
+            NSArray *const subfields = [field subfields];
+            NSUInteger const subfieldCount = [subfields count];
+            for (NSUInteger subfieldIndex = 0; subfieldIndex < subfieldCount; subfieldIndex += 1) {
+                if ([[[subfields objectAtIndex:subfieldIndex] subfieldCode] isEqualToString:subfieldCode]) {
+                    NSUInteger indexes[2] = { index, subfieldIndex };
+                    [indexPaths addObject:[NSIndexPath indexPathWithIndexes:indexes length:2]];
+                }
+            }
         }
     }
     return [indexPaths copy];
@@ -202,32 +247,31 @@
     return [NSArray array];
 }
 
-- (BibControlField *)controlFieldAtIndexPath:(NSIndexPath *)indexPath {
+- (BibRecordField *)fieldAtIndexPath:(NSIndexPath *)indexPath {
     if ([indexPath length] >= 1) {
         NSUInteger const index = [indexPath indexAtPosition:0];
-        NSArray *const controlFields = [self controlFields];
-        if (index < [controlFields count]) {
-            return [controlFields objectAtIndex:index];
+        NSArray *const fields = [self fields];
+        if (index < [fields count]) {
+            return [fields objectAtIndex:index];
         }
     }
     return nil;
 }
 
+- (BibControlField *)controlFieldAtIndexPath:(NSIndexPath *)indexPath {
+    return BibControlFieldFromRecordField([self fieldAtIndexPath:indexPath]);
+}
+
 - (BibContentField *)contentFieldAtIndexPath:(NSIndexPath *)indexPath {
-    if ([indexPath length] >= 1) {
-        NSUInteger const index = [indexPath indexAtPosition:0];
-        NSUInteger const controlFieldsCount = [[self controlFields] count];
-        if (index >= controlFieldsCount) {
-            return [[self contentFields] objectAtIndex:(index - controlFieldsCount)];
-        }
-    }
-    return nil;
+    return BibContentFieldFromRecordField([self fieldAtIndexPath:indexPath]);
 }
 
 - (BibSubfield *)subfieldAtIndexPath:(NSIndexPath *)indexPath {
     if ([indexPath length] >= 2) {
-        BibContentField *const contentField = [self contentFieldAtIndexPath:indexPath];
-        return [contentField subfieldAtIndex:[indexPath indexAtPosition:1]];
+        BibRecordField *const recordField = [[self fields] objectAtIndex:[indexPath indexAtPosition:0]];
+        if ([recordField isDataField]) {
+            return [recordField subfieldAtIndex:[indexPath indexAtPosition:1]];
+        }
     }
     return nil;
 }
@@ -237,13 +281,12 @@
     if (subfield != nil) {
         return [subfield content];
     }
-    BibContentField *const contentField = [self contentFieldAtIndexPath:indexPath];
-    if (contentField != nil) {
-        return [[[contentField subfields] valueForKey:BibKey(content)] componentsJoinedByString:@" "];
+    BibRecordField *const field = [[self fields] objectAtIndex:[indexPath indexAtPosition:0]];
+    if ([field isControlField]) {
+        return field.controlValue;
     }
-    BibControlField *const controlField = [self controlFieldAtIndexPath:indexPath];
-    if (controlField != nil) {
-        return [controlField value];
+    if ([field isDataField]) {
+        return [[[field subfields] valueForKey:BibKey(content)] componentsJoinedByString:@" "];
     }
     NSParameterAssert(NO);
     return nil;
@@ -280,11 +323,10 @@
 @implementation BibMutableRecord
 
 - (id)copyWithZone:(NSZone *)zone {
-    return [[BibMutableRecord allocWithZone:zone] initWithKind:[self kind]
-                                                        status:[self status]
-                                                      metadata:[self metadata]
-                                                 controlFields:[self controlFields]
-                                                 contentFields:[self contentFields]];
+    return [[BibRecord allocWithZone:zone] initWithKind:[self kind]
+                                                 status:[self status]
+                                               metadata:[self metadata]
+                                                 fields:[self fields]];
 }
 
 @dynamic kind;
@@ -310,16 +352,67 @@
 
 @dynamic controlFields;
 - (void)setControlFields:(NSArray<BibControlField *> *)fields {
-    if (_controlFields != fields) {
-        _controlFields = [fields copy];
+    NSMutableArray *newValue = [NSMutableArray new];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == YES", BibKeyPath(isDatafield)];
+    for (BibControlField *field in fields) {
+        [newValue addObject:BibRecordFieldFromControlField(field)];
     }
+    [newValue addObjectsFromArray:[self.fields filteredArrayUsingPredicate:predicate]];
+    self.fields = newValue;
 }
++ (BOOL)automaticallyNotifiesObserversOfControlFields { return NO; }
 
 @dynamic contentFields;
 - (void)setContentFields:(NSArray<BibContentField *> *)fields {
-    if (_contentFields != fields) {
-        _contentFields = [fields copy];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == YES", BibKeyPath(isControlfield)];
+    NSMutableArray *newValue = [[self.fields filteredArrayUsingPredicate:predicate] mutableCopy];
+    for (BibContentField *field in fields) {
+        [newValue addObject:BibRecordFieldFromContentField(field)];
+    }
+    self.fields = newValue;
+}
++ (BOOL)automaticallyNotifiesObserversOfContentFields { return NO; }
+
+@dynamic fields;
+- (void)setFields:(NSArray<BibRecordField *> *)fields {
+    if (_fields != fields) {
+        _fields = [fields copy];
     }
 }
 
 @end
+
+#pragma mark -
+
+static BibControlField *BibControlFieldFromRecordField(BibRecordField *recordField) {
+    if (recordField.isControlField) {
+        return [[BibControlField alloc] initWithTag:recordField.fieldTag value:recordField.controlValue];
+    }
+    return nil;
+}
+
+static BibContentField *BibContentFieldFromRecordField(BibRecordField *recordField) {
+    if (recordField.isDataField) {
+        BibContentIndicatorList *const indicators =
+            [[BibContentIndicatorList alloc] initWithFirstIndicator:recordField.firstIndicator.rawValue
+                                                    secondIndicator:recordField.secondIndicator.rawValue];
+        return [[BibContentField alloc] initWithTag:recordField.fieldTag
+                                         indicators:indicators
+                                          subfields:recordField.subfields];
+    }
+    return nil;
+}
+
+static BibRecordField *BibRecordFieldFromControlField(BibControlField *controlField) {
+    return [[BibRecordField alloc] initWithFieldTag:controlField.tag controlValue:controlField.value];
+}
+
+static BibRecordField *BibRecordFieldFromContentField(BibContentField *contentField) {
+    BibFieldIndicator *const first = [BibFieldIndicator indicatorWithRawValue:contentField.indicators.firstIndicator];
+    BibFieldIndicator *const second = [BibFieldIndicator indicatorWithRawValue:contentField.indicators.secondIndicator];
+    return [[BibRecordField alloc] initWithFieldTag:contentField.tag
+                                     firstIndicator:first
+                                    secondIndicator:second
+                                          subfields:contentField.subfields];
+
+}

--- a/Bibliotek/Record/ContentField/BibContentField.h
+++ b/Bibliotek/Record/ContentField/BibContentField.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// The semantic meaning of a content field is indicated by its \c tag value, and its \c indicators are used as flags
 /// that determine how the data in its subfields should be interpreted or displayed.
 ///
-/// Content fields are composed of \c subfields, which are portions of data semantically identified by their \c code.
+/// Content fields are composed of \c subfields, which are portions of data semantically identified by their \c subfieldCode.
 /// The interpretation of data within a content field is often determined by the formatting of its subfields' contents.
 /// For example, a bibliographic record's title statement, identified with the tag \c 245, formats its content using
 /// ISBD principles and uses subfield codes to semantically tag each piece of the full statement.
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// A collection of byte flags which can indicate how the content field should be interpreted or displayed.
 @property (nonatomic, copy, readonly) BibContentIndicatorList *indicators;
 
-/// An ordered list of subfields containing portions of data semantically identified by their \c code.
+/// An ordered list of subfields containing portions of data semantically identified by their \c subfieldCode.
 /// The interpretation of data within a content field is often determined by the formatting of its subfields' contents.
 /// For example, a bibliographic record's title statement, identified with the tag \c 245, formats its content using
 /// ISBD principles and uses subfield codes to semantically tag each piece of the full statement.
@@ -108,7 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// The semantic meaning of a content field is indicated by its \c tag value, and its \c indicators are used as flags
 /// that determine how the data in its subfields should be interpreted or displayed.
 ///
-/// Content fields are composed of \c subfields, which are portions of data semantically identified by their \c code.
+/// Content fields are composed of \c subfields, which are portions of data semantically identified by their \c subfieldCode.
 /// The interpretation of data within a content field is often determined by the formatting of its subfields' contents.
 /// For example, a bibliographic record's title statement, identified with the tag \c 245, formats its content using
 /// ISBD principles and uses subfield codes to semantically tag each piece of the full statement.
@@ -135,7 +135,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// A collection of byte flags which can indicate how the content field should be interpreted or displayed.
 @property (nonatomic, copy, readwrite) BibContentIndicatorList *indicators;
 
-/// An ordered list of subfields containing portions of data semantically identified by their \c code.
+/// An ordered list of subfields containing portions of data semantically identified by their \c subfieldCode.
 /// The interpretation of data within a content field is often determined by the formatting of its subfields' contents.
 /// For example, a bibliographic record's title statement, identified with the tag \c 245, formats its content using
 /// ISBD principles and uses subfield codes to semantically tag each piece of the full statement.

--- a/Bibliotek/Record/ContentField/BibContentField.h
+++ b/Bibliotek/Record/ContentField/BibContentField.h
@@ -40,6 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// More information about classification records' content fields can be found in the Library of Congress's
 /// documentation on classification records: https://www.loc.gov/marc/classification/
+DEPRECATED_MSG_ATTRIBUTE("replaced with 'BibRecordField'")
 @interface BibContentField : NSObject <BibField>
 
 /// A value indicating the semantic purpose of the content field.
@@ -127,6 +128,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// More information about classification records' content fields can be found in the Library of Congress's
 /// documentation on classification records: https://www.loc.gov/marc/classification/
+DEPRECATED_MSG_ATTRIBUTE("replaced with 'BibMutableRecordField'")
 @interface BibMutableContentField : BibContentField
 
 /// A value indicating the semantic purpose of the content field.

--- a/Bibliotek/Record/ContentField/BibContentField.m
+++ b/Bibliotek/Record/ContentField/BibContentField.m
@@ -121,7 +121,7 @@
     NSUInteger const count = [subfields count];
     for (NSUInteger index = 0; index < count; index += 1) {
         BibSubfield *const subfield = [subfields objectAtIndex:index];
-        if ([[subfield code] isEqualToString:code]) {
+        if ([[subfield subfieldCode] isEqualToString:code]) {
             [indexSet addIndex:index];
         }
     }

--- a/Bibliotek/Record/ContentField/BibContentField.m
+++ b/Bibliotek/Record/ContentField/BibContentField.m
@@ -14,6 +14,8 @@
 
 #import "Bibliotek+Internal.h"
 
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
 @implementation BibContentField {
 @protected
     BibFieldTag *_tag;

--- a/Bibliotek/Record/ContentField/BibSubfield.h
+++ b/Bibliotek/Record/ContentField/BibSubfield.h
@@ -39,7 +39,7 @@ typedef NSString *BibSubfieldCode NS_EXTENSIBLE_STRING_ENUM NS_SWIFT_NAME(Subfie
 
 #pragma mark - Copying
 
-@interface BibSubfield (Copying) <NSCopying>
+@interface BibSubfield (Copying) <NSCopying, NSSecureCoding>
 @end
 
 #pragma mark - Equality

--- a/Bibliotek/Record/ContentField/BibSubfield.h
+++ b/Bibliotek/Record/ContentField/BibSubfield.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// MARC 21 subfield codes are always a single ASCII graphic character.
 typedef NSString *BibSubfieldCode NS_EXTENSIBLE_STRING_ENUM NS_SWIFT_NAME(SubfieldCode);
 
-/// A portion of data in a content field semantically identified by its \c code.
+/// A portion of data in a content field semantically identified by its \c subfieldCode.
 ///
 /// Content fields hold data within labeled subfields. Each subfield's identifier marks the semantic meaning of its
 /// content, which is determined by the record field's tag as defined in the appropriate MARC 21 format specification.
@@ -24,16 +24,16 @@ typedef NSString *BibSubfieldCode NS_EXTENSIBLE_STRING_ENUM NS_SWIFT_NAME(Subfie
 /// A record subfield's identifier identifies the semantic purpose of the content within a subfield.
 ///
 /// The semantics of each identifier is determined by the record field's tag as defined in the relevant MARC 21 format.
-@property (nonatomic, copy, readonly) BibSubfieldCode code;
+@property (nonatomic, copy, readonly) BibSubfieldCode subfieldCode;
 
 /// A string representation of the information stored in the subfield.
 @property (nonatomic, copy, readonly) NSString *content;
 
 /// Create a subfield of data for use within a record's data field.
-/// \param code An alphanumeric identifier for semantic purpose of the subfield's content.
+/// \param subfieldCode An alphanumeric identifier for semantic purpose of the subfield's content.
 /// \param content A string representation of the data stored within the subfield.
 /// \returns Returns a subfield value when the given subfield identifier is well-formatted.
-- (instancetype)initWithCode:(BibSubfieldCode)code content:(NSString *)content NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCode:(BibSubfieldCode)subfieldCode content:(NSString *)content NS_DESIGNATED_INITIALIZER;
 
 @end
 
@@ -48,14 +48,14 @@ typedef NSString *BibSubfieldCode NS_EXTENSIBLE_STRING_ENUM NS_SWIFT_NAME(Subfie
 
 /// Determine if this subfield and its data is equivalent to that of the given subfield.
 /// \param subfield The subfield that is being compaired with this instance for equality.
-/// \returns Returns \c YES when both fields have the same code and content.
+/// \returns Returns \c YES when both fields have the same subfieldCode and content.
 - (BOOL)isEqualToSubfield:(BibSubfield *)subfield;
 
 @end
 
 #pragma mark - Mutable
 
-/// A mutable portion of data in a content field semantically identified by its \c code.
+/// A mutable portion of data in a content field semantically identified by its \c subfieldCode.
 ///
 /// Content fields hold data within labeled subfields. Each subfield's identifier marks the semantic meaning of its
 /// content, which is determined by the record field's tag as defined in the appropriate MARC 21 format specification.

--- a/Bibliotek/Record/ContentField/BibSubfield.m
+++ b/Bibliotek/Record/ContentField/BibSubfield.m
@@ -62,6 +62,19 @@
     return [[BibMutableSubfield allocWithZone:zone] initWithCode:[self code] content:[self content]];
 }
 
++ (BOOL)supportsSecureCoding { return YES; }
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+    BibSubfieldCode const code = [coder decodeObjectOfClass:[NSString self] forKey:BibKey(code)];
+    NSString *const content = [coder decodeObjectOfClass:[NSString self] forKey:BibKey(content)];
+    return [self initWithCode:code content:content];
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+    [coder encodeObject:[self code] forKey:BibKey(code)];
+    [coder encodeObject:[self content] forKey:BibKey(content)];
+}
+
 @end
 
 #pragma mark - Equality

--- a/Bibliotek/Record/ContentField/BibSubfield.m
+++ b/Bibliotek/Record/ContentField/BibSubfield.m
@@ -13,16 +13,16 @@
 
 @implementation BibSubfield {
 @protected
-    BibSubfieldCode _code;
+    BibSubfieldCode _subfieldCode;
     NSString *_content;
 }
 
-@synthesize code = _code;
+@synthesize subfieldCode = _subfieldCode;
 @synthesize content = _content;
 
 - (instancetype)initWithCode:(BibSubfieldCode)code content:(NSString *)content {
     if (self = [super init]) {
-        _code = [code copy];
+        _subfieldCode = [code copy];
         _content = [content copy];
     }
     return self;
@@ -41,7 +41,7 @@
 }
 
 - (NSString *)debugDescription {
-    return [NSString stringWithFormat:@"\u2021%@%@", [self code], [self content]];
+    return [NSString stringWithFormat:@"\u2021%@%@", [self subfieldCode], [self content]];
 }
 
 + (NSSet *)keyPathsForValuesAffectingDebugDescription {
@@ -59,7 +59,7 @@
 }
 
 - (id)mutableCopyWithZone:(NSZone *)zone {
-    return [[BibMutableSubfield allocWithZone:zone] initWithCode:[self code] content:[self content]];
+    return [[BibMutableSubfield allocWithZone:zone] initWithCode:[self subfieldCode] content:[self content]];
 }
 
 + (BOOL)supportsSecureCoding { return YES; }
@@ -71,7 +71,7 @@
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
-    [coder encodeObject:[self code] forKey:BibKey(code)];
+    [coder encodeObject:[self subfieldCode] forKey:BibKey(code)];
     [coder encodeObject:[self content] forKey:BibKey(content)];
 }
 
@@ -82,7 +82,8 @@
 @implementation BibSubfield (Equality)
 
 - (BOOL)isEqualToSubfield:(BibSubfield *)subfield {
-    return [self code] == [subfield code] && [[self content] isEqualToString:[subfield content]];
+    return [[self subfieldCode] isEqualToString:[subfield subfieldCode]]
+        && [[self content] isEqualToString:[subfield content]];
 }
 
 - (BOOL)isEqual:(id)object {
@@ -92,7 +93,7 @@
 
 - (NSUInteger)hash {
     BibHasher *const hasher = [BibHasher new];
-    [hasher combineWithObject:[self code]];
+    [hasher combineWithObject:[self subfieldCode]];
     [hasher combineWithObject:[self content]];
     return [hasher hash];
 }
@@ -104,13 +105,13 @@
 @implementation BibMutableSubfield
 
 - (id)copyWithZone:(NSZone *)zone {
-    return [[BibSubfield allocWithZone:zone] initWithCode:[self code] content:[self content]];
+    return [[BibSubfield allocWithZone:zone] initWithCode:[self subfieldCode] content:[self content]];
 }
 
 @dynamic code;
 - (void)setCode:(BibSubfieldCode)code {
-    if (_code != code) {
-        _code = [code copy];
+    if (_subfieldCode != code) {
+        _subfieldCode = [code copy];
     }
 }
 
@@ -150,7 +151,7 @@
 
 - (BibSubfield *)nextSubfieldWithCode:(BibSubfieldCode)subfieldCode {
     for (BibSubfield *subfield = [self nextSubfield]; subfield != nil; subfield = [self nextSubfield]) {
-        if ([[subfield code] isEqualToString:subfieldCode]) {
+        if ([[subfield subfieldCode] isEqualToString:subfieldCode]) {
             return subfield;
         }
     }

--- a/Bibliotek/Record/ContentField/BibSubfield.m
+++ b/Bibliotek/Record/ContentField/BibSubfield.m
@@ -41,7 +41,7 @@
 }
 
 - (NSString *)debugDescription {
-    return [NSString stringWithFormat:@"$%@%@", [self code], [self content]];
+    return [NSString stringWithFormat:@"\u2021%@%@", [self code], [self content]];
 }
 
 + (NSSet *)keyPathsForValuesAffectingDebugDescription {

--- a/Bibliotek/Record/ContentField/ContentField.swift
+++ b/Bibliotek/Record/ContentField/ContentField.swift
@@ -38,6 +38,7 @@ import Foundation
 /// [spec-home]: https://www.loc.gov/marc/specifications/spechome.html
 /// [isbd-wikipedia]: https://en.wikipedia.org/wiki/International_Standard_Bibliographic_Description
 /// [isbd-spec]: https://www.ifla.org/files/assets/cataloguing/isbd/isbd-cons_20110321.pdf
+@available(*, deprecated, message: "replaced with 'RecordField'")
 public struct ContentField {
     private var _storage: BibContentField!
     private var _mutableStorage: BibMutableContentField!
@@ -95,6 +96,7 @@ public struct ContentField {
     }
 }
 
+@available(*, deprecated)
 extension ContentField: Hashable, Equatable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(self.storage)
@@ -105,6 +107,7 @@ extension ContentField: Hashable, Equatable {
     }
 }
 
+@available(*, deprecated)
 extension ContentField: CustomStringConvertible, CustomPlaygroundDisplayConvertible {
     public var description: String { return self.storage.description }
 
@@ -113,6 +116,7 @@ extension ContentField: CustomStringConvertible, CustomPlaygroundDisplayConverti
                                                     "subfields": self.subfields] }
 }
 
+@available(*, deprecated)
 extension ContentField {
     public func indexesOfSubfields(with code: SubfieldCode) -> IndexSet {
         return self.storage.indexesOfSubfields(withCode: code)
@@ -133,6 +137,7 @@ extension ContentField {
 
 // MARK: - Bridging
 
+@available(*, deprecated)
 extension ContentField: _ObjectiveCBridgeable {
     public typealias _ObjectiveCType = BibContentField
 
@@ -154,6 +159,7 @@ extension ContentField: _ObjectiveCBridgeable {
     }
 }
 
+@available(*, deprecated)
 extension BibContentField: CustomPlaygroundDisplayConvertible {
     public var playgroundDescription: Any { return (self as ContentField).playgroundDescription }
 }

--- a/Bibliotek/Record/ContentField/Subfield.swift
+++ b/Bibliotek/Record/ContentField/Subfield.swift
@@ -67,6 +67,26 @@ extension Subfield: Hashable, Equatable {
     }
 }
 
+extension Subfield: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case code
+        case content
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let code = try container.decode(SubfieldCode.RawValue.self, forKey: .code)
+        let content = try container.decode(String.self, forKey: .content)
+        self.init(code: SubfieldCode(rawValue: code), content: content)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.code.rawValue, forKey: .code)
+        try container.encode(self.content, forKey: .content)
+    }
+}
+
 extension Subfield: CustomStringConvertible, CustomPlaygroundDisplayConvertible {
     public var description: String { return self.storage.description }
 

--- a/Bibliotek/Record/ContentField/Subfield.swift
+++ b/Bibliotek/Record/ContentField/Subfield.swift
@@ -21,7 +21,7 @@ public struct Subfield {
     ///
     /// The semantics of each identifier is determined by the record field's tag as defined in the relevant MARC 21 format.
     public var code: SubfieldCode {
-        get { return self.storage.code }
+        get { return self.storage.subfieldCode }
         set { self.mutate(keyPath: \.code, with: newValue) }
     }
 

--- a/Bibliotek/Record/ControlField.swift
+++ b/Bibliotek/Record/ControlField.swift
@@ -22,6 +22,7 @@ import Foundation
 /// [spec-home]: https://www.loc.gov/marc/specifications/spechome.html
 /// [bib-control]: http://www.loc.gov/marc/bibliographic/bd00x.html
 /// [cls-control]: https://www.loc.gov/marc/classification/cd00x.html
+@available(*, deprecated, message: "replaced with 'RecordField'")
 public struct ControlField {
     private var _storage: BibControlField!
     private var _mutableStorage: BibMutableControlField!
@@ -61,6 +62,7 @@ public struct ControlField {
 
 // MARK: -
 
+@available(*, deprecated)
 extension ControlField: Hashable, Equatable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(self.storage)
@@ -71,6 +73,7 @@ extension ControlField: Hashable, Equatable {
     }
 }
 
+@available(*, deprecated)
 extension ControlField: CustomStringConvertible, CustomPlaygroundDisplayConvertible {
     public var description: String { return self.storage.description }
 
@@ -79,6 +82,7 @@ extension ControlField: CustomStringConvertible, CustomPlaygroundDisplayConverti
 
 // MARK: - Bridging
 
+@available(*, deprecated)
 extension ControlField: _ObjectiveCBridgeable {
     public typealias _ObjectiveCType = BibControlField
 
@@ -100,6 +104,7 @@ extension ControlField: _ObjectiveCBridgeable {
     }
 }
 
+@available(*, deprecated)
 extension BibControlField: CustomPlaygroundDisplayConvertible {
     public var playgroundDescription: Any { return (self as ControlField).playgroundDescription }
 }

--- a/Bibliotek/Record/Primitives/BibFieldPath.h
+++ b/Bibliotek/Record/Primitives/BibFieldPath.h
@@ -19,7 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, copy, nullable) BibSubfieldCode subfieldCode;
 
 @property (nonatomic, readonly) BOOL isControlFieldPath;
-@property (nonatomic, readonly) BOOL isContentFieldPath;
+@property (nonatomic, readonly) BOOL isContentFieldPath DEPRECATED_MSG_ATTRIBUTE("Use -isDataFieldPath");
+@property (nonatomic, readonly) BOOL isDataFieldPath;
 @property (nonatomic, readonly) BOOL isSubfieldPath;
 
 - (instancetype)initWithFieldTag:(BibFieldTag *)fieldTag NS_DESIGNATED_INITIALIZER;

--- a/Bibliotek/Record/Primitives/BibFieldPath.m
+++ b/Bibliotek/Record/Primitives/BibFieldPath.m
@@ -30,21 +30,25 @@
 - (instancetype)initWithFieldTag:(BibFieldTag *)fieldTag subfieldCode:(BibSubfieldCode)subfieldCode {
     if (self = [super init]) {
         _fieldTag = [fieldTag copy];
-        _subfieldCode = [fieldTag isControlFieldTag] ? nil : [subfieldCode copy];
+        _subfieldCode = [fieldTag isControlTag] ? nil : [subfieldCode copy];
     }
     return self;
 }
 
 - (BOOL)isSubfieldPath {
-    return ![[self fieldTag] isControlFieldTag] && ([self subfieldCode] != nil);
+    return [[self fieldTag] isDataTag] && ([self subfieldCode] != nil);
+}
+
+- (BOOL)isDataFieldPath {
+    return [[self fieldTag] isDataTag] && ([self subfieldCode] == nil);
 }
 
 - (BOOL)isContentFieldPath {
-    return ![[self fieldTag] isControlFieldTag] && ([self subfieldCode] == nil);
+    return [self isDataFieldPath];
 }
 
 - (BOOL)isControlFieldPath {
-    return [[self fieldTag] isControlFieldTag];
+    return [[self fieldTag] isControlTag];
 }
 
 - (id)copyWithZone:(NSZone *)zone {

--- a/Bibliotek/Record/Primitives/BibFieldTag.h
+++ b/Bibliotek/Record/Primitives/BibFieldTag.h
@@ -25,7 +25,22 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// MARC 21 control field tags always begin with two zeros.
 /// For example, a record's control number field has the tag \c 001.
-@property (nonatomic, assign, readonly, getter=isControlFieldTag) BOOL controlFieldTag;
+@property (nonatomic, assign, readonly, getter=isControlFieldTag) BOOL controlFieldTag
+    DEPRECATED_MSG_ATTRIBUTE("Use -isControlTag");
+
+/// Does the tag identify a control field?
+///
+/// MARC 21 controlfield tags always begin with two zeros.
+/// For example, a record's control number controlfield has the tag \c 001.
+///
+/// \note The tag \c 000 is neither a controlfield tag nor a datafield tag.
+@property (nonatomic, assign, readonly) BOOL isControlTag;
+
+/// Does the tag identify a data field?
+///
+/// MARC 21 datafield tags never begin with two zeros.
+/// For example, a bibliographic record's Library of Conrgess call number datafield has the tag \c 050.
+@property (nonatomic, assign, readonly) BOOL isDataTag;
 
 /// Create a tag with the given string value.
 ///

--- a/Bibliotek/Record/Primitives/BibFieldTag.h
+++ b/Bibliotek/Record/Primitives/BibFieldTag.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// MARC 21 Record Structure: https://www.loc.gov/marc/specifications/spechome.html
 ///
 /// \note MARC 21 tags are always 3 digit codes.
-@interface BibFieldTag : NSObject <NSCopying>
+@interface BibFieldTag : NSObject <NSCopying, NSSecureCoding>
 
 /// A string contianing the 3-character value of the tag.
 @property (nonatomic, copy, readonly) NSString *stringValue;

--- a/Bibliotek/Record/Primitives/BibFieldTag.m
+++ b/Bibliotek/Record/Primitives/BibFieldTag.m
@@ -29,8 +29,8 @@
     }
     if (self = [super init]) {
         _stringValue = [stringValue copy];
-        _isDataTag = [stringValue hasPrefix:@"00"];
-        _isControlTag = !_isDataTag && ![stringValue isEqualToString:@"000"];
+        _isControlTag = [stringValue hasPrefix:@"00"];
+        _isDataTag = !_isControlTag && ![stringValue isEqualToString:@"000"];
     }
     return self;
 }

--- a/Bibliotek/Record/Primitives/BibFieldTag.m
+++ b/Bibliotek/Record/Primitives/BibFieldTag.m
@@ -47,6 +47,16 @@
     return [self initWithString:@"000"];
 }
 
++ (BOOL)supportsSecureCoding { return YES; }
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+    return [self initWithData:[coder decodeDataObject]];
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+    [coder encodeDataObject:[[self stringValue] dataUsingEncoding:NSASCIIStringEncoding]];
+}
+
 - (NSString *)description {
     return [self stringValue];
 }

--- a/Bibliotek/Record/Primitives/BibFieldTag.m
+++ b/Bibliotek/Record/Primitives/BibFieldTag.m
@@ -14,6 +14,8 @@
 @implementation BibFieldTag
 
 @synthesize stringValue = _stringValue;
+@synthesize isControlTag = _isControlTag;
+@synthesize isDataTag = _isDataTag;
 
 + (instancetype)allocWithZone:(struct _NSZone *)zone {
     return [self isEqualTo:[BibFieldTag class]]
@@ -27,6 +29,8 @@
     }
     if (self = [super init]) {
         _stringValue = [stringValue copy];
+        _isDataTag = [stringValue hasPrefix:@"00"];
+        _isControlTag = !_isDataTag && ![stringValue isEqualToString:@"000"];
     }
     return self;
 }
@@ -45,10 +49,6 @@
 
 - (NSString *)description {
     return [self stringValue];
-}
-
-- (BOOL)isControlFieldTag {
-    return [[self stringValue] hasPrefix:@"00"];
 }
 
 - (id)copyWithZone:(NSZone *)zone {

--- a/Bibliotek/Record/Primitives/FieldPath.swift
+++ b/Bibliotek/Record/Primitives/FieldPath.swift
@@ -17,7 +17,7 @@ public enum FieldPath: Hashable, Equatable {
     }
 
     public init(tag: FieldTag, code: SubfieldCode) {
-        precondition(!tag.isControlFieldTag)
+        precondition(!tag.isControlTag)
         self = .subfieldPath(tag: tag, code: code)
     }
 }
@@ -39,14 +39,14 @@ extension FieldPath {
 
     public var isControlFieldPath: Bool {
         switch self {
-        case let .fieldPath(tag: tag): return tag.isControlFieldTag
+        case let .fieldPath(tag: tag): return tag.isControlTag
         case .subfieldPath(tag: _, code: _): return false
         }
     }
 
     public var isContentFieldPath: Bool {
         switch self {
-        case let .fieldPath(tag: tag): return !tag.isControlFieldTag
+        case let .fieldPath(tag: tag): return !tag.isControlTag
         case .subfieldPath(tag: _, code: _): return false
         }
     }

--- a/Bibliotek/Record/Primitives/FieldTag.swift
+++ b/Bibliotek/Record/Primitives/FieldTag.swift
@@ -70,6 +70,19 @@ extension FieldTag: Hashable, Equatable {
     }
 }
 
+extension FieldTag: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        self.init(rawValue: rawValue)!
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
+    }
+}
+
 extension FieldTag: CustomStringConvertible, CustomPlaygroundDisplayConvertible {
     public var description: String { return self.storage.description }
 
@@ -99,6 +112,16 @@ extension FieldTag: _ObjectiveCBridgeable {
     }
 }
 
-extension BibFieldTag: CustomPlaygroundDisplayConvertible {
+extension BibFieldTag: RawRepresentable, ExpressibleByStringLiteral, CustomPlaygroundDisplayConvertible {
+    public var rawValue: String { return self.stringValue }
+
+    public required convenience init?(rawValue: String) {
+        self.init(string: rawValue)
+    }
+
+    public required convenience init(stringLiteral value: String) {
+        self.init(string: value)!
+    }
+
     public var playgroundDescription: Any { return (self as FieldTag).playgroundDescription }
 }

--- a/Bibliotek/Record/Primitives/FieldTag.swift
+++ b/Bibliotek/Record/Primitives/FieldTag.swift
@@ -25,7 +25,22 @@ public struct FieldTag {
     ///
     /// MARC 21 control field tags always begin with two zeros.
     /// For example, a record's control number field has the tag `001`.
+    @available(*, deprecated, message: "Use isControlTag")
     public var isControlFieldTag: Bool { return self.storage.isControlFieldTag }
+
+    /// Does the tag identify a control field?
+    ///
+    /// MARC 21 controlfield tags always begin with two zeros.
+    /// For example, a record's control number controlfield has the tag `001`.
+    ///
+    /// - note: The tag `000` is neither a controlfield tag nor a datafield tag.
+    public var isControlTag: Bool { return self.storage.isControlTag }
+
+    /// Does the tag identify a data field?
+    ///
+    /// MARC 21 datafield tags never begin with two zeros.
+    /// For example, a bibliographic record's Library of Conrgess call number datafield has the tag `050`.
+    public var isDataTag: Bool { return self.storage.isDataTag }
 
     private init(storage: BibFieldTag) {
         self.storage = storage

--- a/Bibliotek/Record/Record.swift
+++ b/Bibliotek/Record/Record.swift
@@ -163,19 +163,31 @@ extension Record {
 }
 
 extension Record {
+    /// Test to see if the record contains a field with the given tag.
+    /// - parameter tag: If this record has a field with this value, \c YES is returned.
+    /// - returns: `true` if at least one record field is marked with the given tag.
     public func containsField(with tag: FieldTag) -> Bool {
         return self.indexOfField(with: tag) != nil
     }
 
+    /// Get the index of the first record field with the given tag.
+    /// - parameter tag: The field tag marking the data field or control field to access.
+    /// - returns: The index of the first record with the given tag. If no such field exists, `nil` is returned.
     public func indexOfField(with tag: FieldTag) -> Int? {
         let fields = self.fields
         return fields.indices.first(where: { fields[$0].tag == tag })
     }
 
+    /// Get the first record field with the given tag.
+    /// - parameter fieldTag: The field tag marking the data field or control field to access.
+    /// - returns: The first record with the given tag. If no such field exists, `nil` is returned.
     public func field(with tag: FieldTag) -> RecordField? {
         return self.indexOfField(with: tag).map(self.field(at:))
     }
 
+    /// Get the field at the given index.
+    /// - parameter index: The index of the record field to access.
+    /// - returns: The data field or control field located at the given index.
     public func field(at index: Int) -> RecordField {
         return self.fields[index]
     }
@@ -194,14 +206,26 @@ extension Record {
         return self.storage.indexPaths(for: tag as BibFieldTag, code: code)
     }
 
+    /// Get the record field referenced by the given index path.
+    /// - parameter indexPath: The index path value pointing to the field or one of its subfields.
+    /// - returns: The record field referenced by the index path.
+    ///            If the index path points to a subfield, its field is returned.
     public func field(at indexPath: IndexPath) -> RecordField {
         return self.storage.field(at: indexPath) as RecordField
     }
 
+    /// Get the subfield referenced by the given index path.
+    /// - parameter indexPath: The index path value pointing to a specific subfield value.
+    /// - returns: The subfield object referenced byt the index path.
+    /// - note: This method will fatally error when given an index path that points to a field instead of its subfield,
+    ///         or if the index path points into a control field instead of a data field.
     public func subfield(at indexPath: IndexPath) -> Subfield {
         return self.storage.subfield(at: indexPath) as Subfield
     }
 
+    /// Get a string representation of the value stored at the given index path.
+    /// - parameter indexPath: The index path of a control field, data field, or subfield.
+    /// - returns: A string representation of the data within the referenced control field, data field, or subfield.
     public func content(at indexPath: IndexPath) -> String {
         return self.storage.content(at: indexPath)
     }

--- a/Bibliotek/Record/Record.swift
+++ b/Bibliotek/Record/Record.swift
@@ -52,15 +52,23 @@ public struct Record {
     }
 
     /// An ordered list of fields containing information and metadata about how a record's content should be processed.
+    @available(*, deprecated, message: "Use fields")
     public var controlFields: [ControlField] {
         get { return self.storage.controlFields as [ControlField] }
         set { self.mutate(keyPath: \.controlFields, with: newValue as [BibControlField]) }
     }
 
     /// An ordered list of fields containing information and metadata about the item represented by a record.
+    @available(*, deprecated, message: "Use fields")
     public var contentFields: [ContentField] {
         get { return self.storage.contentFields as [ContentField] }
         set { self.mutate(keyPath: \.contentFields, with: newValue as [BibContentField]) }
+    }
+
+    /// An ordered list of fields containing information and metadata about the record and its represented item.
+    public var fields: [BibRecordField] {
+        get { return self.storage.fields }
+        set { self.mutate(keyPath: \.fields, with: newValue) }
     }
 
     private init(storage: BibRecord) {
@@ -114,15 +122,16 @@ extension Record: CustomStringConvertible, CustomPlaygroundDisplayConvertible {
     public var playgroundDescription: Any { return ["kind": self.kind?.description ?? "unset",
                                                     "status": String(format: "%c", self.status.rawValue),
                                                     "meatdata": self.metadata,
-                                                    "controlFields": self.contentFields,
-                                                    "contentFields": self.contentFields] }
+                                                    "fields": self.fields] }
 }
 
 extension Record {
+    @available(*, deprecated, message: "")
     public func controlFields(with tag: FieldTag) -> LazyFilterSequence<[ControlField]> {
         return self.controlFields.lazy.filter { $0.tag == tag }
     }
 
+    @available(*, deprecated, message: "")
     public func contentFields(with tag: FieldTag) -> LazyFilterSequence<[ContentField]> {
         return self.contentFields.lazy.filter { $0.tag == tag }
     }
@@ -131,16 +140,30 @@ extension Record {
         return self.storage.indexPaths(for: fieldPath as BibFieldPath)
     }
 
+    public func indexPaths(for tag: FieldTag) -> [IndexPath] {
+        return self.storage.indexPaths(for: tag as BibFieldTag)
+    }
+
+    public func indexPaths(for tag: FieldTag, code: SubfieldCode) -> [IndexPath] {
+        return self.storage.indexPaths(for: tag as BibFieldTag, code: code)
+    }
+
+    @available(*, deprecated, message: "Use field(at:)")
     public func controlField(at indexPath: IndexPath) -> ControlField? {
         return self.storage.controlField(at: indexPath) as ControlField?
     }
 
+    @available(*, deprecated, message: "Use field(at:)")
     public func contentField(at indexPath: IndexPath) -> ContentField? {
         return self.storage.contentField(at: indexPath) as ContentField?
     }
 
-    public func subfield(at indexPath: IndexPath) -> Subfield? {
-        return self.storage.subfield(at: indexPath) as Subfield?
+    public func field(at indexPath: IndexPath) -> RecordField {
+        return self.storage.field(at: indexPath) as RecordField
+    }
+
+    public func subfield(at indexPath: IndexPath) -> Subfield {
+        return self.storage.subfield(at: indexPath) as Subfield
     }
 
     public func content(at indexPath: IndexPath) -> String {

--- a/Bibliotek/Record/Record.swift
+++ b/Bibliotek/Record/Record.swift
@@ -66,9 +66,9 @@ public struct Record {
     }
 
     /// An ordered list of fields containing information and metadata about the record and its represented item.
-    public var fields: [BibRecordField] {
-        get { return self.storage.fields }
-        set { self.mutate(keyPath: \.fields, with: newValue) }
+    public var fields: [RecordField] {
+        get { return self.storage.fields as [RecordField] }
+        set { self.mutate(keyPath: \.fields, with: newValue as [BibRecordField]) }
     }
 
     private init(storage: BibRecord) {
@@ -136,6 +136,37 @@ extension Record {
         return self.contentFields.lazy.filter { $0.tag == tag }
     }
 
+    @available(*, deprecated, message: "Use field(at:)")
+    public func controlField(at indexPath: IndexPath) -> ControlField? {
+        return self.storage.controlField(at: indexPath) as ControlField?
+    }
+
+    @available(*, deprecated, message: "Use field(at:)")
+    public func contentField(at indexPath: IndexPath) -> ContentField? {
+        return self.storage.contentField(at: indexPath) as ContentField?
+    }
+}
+
+extension Record {
+    public func containsField(with tag: FieldTag) -> Bool {
+        return self.indexOfField(with: tag) != nil
+    }
+
+    public func indexOfField(with tag: FieldTag) -> Int? {
+        let fields = self.fields
+        return fields.indices.first(where: { fields[$0].tag == tag })
+    }
+
+    public func field(with tag: FieldTag) -> RecordField? {
+        return self.indexOfField(with: tag).map(self.field(at:))
+    }
+
+    public func field(at index: Int) -> RecordField {
+        return self.fields[index]
+    }
+}
+
+extension Record {
     public func indexPaths(for fieldPath: FieldPath) -> [IndexPath] {
         return self.storage.indexPaths(for: fieldPath as BibFieldPath)
     }
@@ -146,16 +177,6 @@ extension Record {
 
     public func indexPaths(for tag: FieldTag, code: SubfieldCode) -> [IndexPath] {
         return self.storage.indexPaths(for: tag as BibFieldTag, code: code)
-    }
-
-    @available(*, deprecated, message: "Use field(at:)")
-    public func controlField(at indexPath: IndexPath) -> ControlField? {
-        return self.storage.controlField(at: indexPath) as ControlField?
-    }
-
-    @available(*, deprecated, message: "Use field(at:)")
-    public func contentField(at indexPath: IndexPath) -> ContentField? {
-        return self.storage.contentField(at: indexPath) as ContentField?
     }
 
     public func field(at indexPath: IndexPath) -> RecordField {

--- a/Bibliotek/Record/Record.swift
+++ b/Bibliotek/Record/Record.swift
@@ -52,14 +52,14 @@ public struct Record {
     }
 
     /// An ordered list of fields containing information and metadata about how a record's content should be processed.
-    @available(*, deprecated, message: "Use fields")
+    @available(*, deprecated, message: "replaced with 'fields'")
     public var controlFields: [ControlField] {
         get { return self.storage.controlFields as [ControlField] }
         set { self.mutate(keyPath: \.controlFields, with: newValue as [BibControlField]) }
     }
 
     /// An ordered list of fields containing information and metadata about the item represented by a record.
-    @available(*, deprecated, message: "Use fields")
+    @available(*, deprecated, message: "replaced with 'fields'")
     public var contentFields: [ContentField] {
         get { return self.storage.contentFields as [ContentField] }
         set { self.mutate(keyPath: \.contentFields, with: newValue as [BibContentField]) }
@@ -83,6 +83,7 @@ public struct Record {
     /// - parameter controlFields: An ordered list of fields describing how the record should be processed.
     /// - parameter contentFields: An ordered list of fields describing the item represented by the record.
     /// - returns: Returns a valid MARC 21 record for some item or entity described by the given fields.
+    @available(*, deprecated, message: "replaced with 'init(kindLstatus:metadata:fields:)'")
     public init(kind: RecordKind?, status: RecordStatus, metadata: Metadata,
                 controlFields: [ControlField], contentFields: [ContentField]) {
         self._storage = BibRecord(kind: kind as BibRecordKind?,
@@ -90,6 +91,20 @@ public struct Record {
                                   metadata: metadata as BibMetadata,
                                   controlFields: controlFields as [BibControlField],
                                   contentFields: contentFields as [BibContentField])
+    }
+
+    /// Create a MARC 21 record with the given data.
+    ///
+    /// - parameter kind: The type of record.
+    /// - parameter status: The record's status in its originating database.
+    /// - parameter metadata: A set of implementation-defined bytes.
+    /// - parameter fields: An ordered list of fields describing the item represented by the record.
+    /// - returns: Returns a valid MARC 21 record for some item or entity described by the given fields.
+    public init(kind: RecordKind?, status: RecordStatus, metadata: Metadata, fields: [RecordField]) {
+        self._storage = BibRecord(kind: kind as BibRecordKind?,
+                                  status: status,
+                                  metadata: metadata as BibMetadata,
+                                  fields: fields as [BibRecordField])
     }
 
     private mutating func mutate<T>(keyPath: WritableKeyPath<BibMutableRecord, T>, with newValue: T) {
@@ -126,22 +141,22 @@ extension Record: CustomStringConvertible, CustomPlaygroundDisplayConvertible {
 }
 
 extension Record {
-    @available(*, deprecated, message: "")
+    @available(*, deprecated)
     public func controlFields(with tag: FieldTag) -> LazyFilterSequence<[ControlField]> {
         return self.controlFields.lazy.filter { $0.tag == tag }
     }
 
-    @available(*, deprecated, message: "")
+    @available(*, deprecated)
     public func contentFields(with tag: FieldTag) -> LazyFilterSequence<[ContentField]> {
         return self.contentFields.lazy.filter { $0.tag == tag }
     }
 
-    @available(*, deprecated, message: "Use field(at:)")
+    @available(*, deprecated, message: "replaced with 'field(at:)'")
     public func controlField(at indexPath: IndexPath) -> ControlField? {
         return self.storage.controlField(at: indexPath) as ControlField?
     }
 
-    @available(*, deprecated, message: "Use field(at:)")
+    @available(*, deprecated, message: "replaced with 'field(at:)'")
     public func contentField(at indexPath: IndexPath) -> ContentField? {
         return self.storage.contentField(at: indexPath) as ContentField?
     }

--- a/Bibliotek/Record/RecordField/BibFieldIndicator.h
+++ b/Bibliotek/Record/RecordField/BibFieldIndicator.h
@@ -36,18 +36,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithRawValue:(char)rawValue;
 
 /// Create an indicator with the given raw value.
-/// \param value An ASCII space, lowercase letter, or number.
-/// \returns An indicator object with some semantic metadata meaning about a data field.
-/// \note This method will throw an out-of-bounds exception for invalid indicator characters.
-- (instancetype)initWithValue:(char)value NS_SWIFT_NAME(init(_:));
-
-/// Create an indicator with the given raw value.
-/// \param value An ASCII space, lowercase letter, or number.
-/// \returns An indicator object with some semantic metadata meaning about a data field.
-/// \note This method will throw an out-of-bounds exception for invalid indicator characters.
-+ (instancetype)indicatorWithValue:(char)value NS_SWIFT_UNAVAILABLE("Use init(_:)");
-
-/// Create an indicator with the given raw value.
 /// \param rawValue An ASCII space, lowercase letter, or number.
 /// \returns An indicator object with some semantic metadata meaning about a data field.
 /// \note This method will throw an out-of-bounds exception for invalid indicator characters.

--- a/Bibliotek/Record/RecordField/BibFieldIndicator.h
+++ b/Bibliotek/Record/RecordField/BibFieldIndicator.h
@@ -18,10 +18,6 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// More information about MARC 21 records can be found in the Library of Congress's documentation on
 /// MARC 21 Record Structure: https://www.loc.gov/marc/specifications/specrecstruc.html
-///
-/// \note It is \b not safe to subclass \c BibFieldIndicator
-NS_SWIFT_NAME(FieldIndicator)
-__attribute__((objc_subclassing_restricted))
 @interface BibFieldIndicator : NSObject <NSCopying, NSSecureCoding>
 
 /// The ASCII value backing this indicator object.

--- a/Bibliotek/Record/RecordField/BibFieldIndicator.h
+++ b/Bibliotek/Record/RecordField/BibFieldIndicator.h
@@ -1,0 +1,78 @@
+//
+//  BibFieldIndicator.h
+//  Bibliotek
+//
+//  Created by Steve Brunwasser on 6/7/20.
+//  Copyright © 2020 Steve Brunwasser. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A metadata value assigning some semantic meaning to a data field.
+///
+/// Indicators are backed by an ASCII space character, an ASCII lowercase letter, or an ASCII number.
+/// Indicators are genally considered "blank" or "empty" when backed by an ASCII space character, but that value
+/// may also have some meaning depending on the semantic definition of the field.
+///
+/// More information about MARC 21 records can be found in the Library of Congress's documentation on
+/// MARC 21 Record Structure: https://www.loc.gov/marc/specifications/specrecstruc.html
+///
+/// \note It is \b not safe to subclass \c BibFieldIndicator
+NS_SWIFT_NAME(FieldIndicator)
+__attribute__((objc_subclassing_restricted))
+@interface BibFieldIndicator : NSObject <NSCopying, NSSecureCoding>
+
+/// The ASCII value backing this indicator object.
+@property (nonatomic, readonly, assign) char rawValue;
+
+/// An indicator backed by an ASCII space character.
+///
+/// "Blank" indicators generally represent the absence of an assigned value, but may also be considered ameaningful
+/// meaningful depending on the semantic definition of the field.
+@property (class, nonatomic, readonly) BibFieldIndicator *blank;
+
+/// Create an indicator with the given raw value.
+/// \param rawValue An ASCII space, lowercase letter, or number.
+/// \returns An indicator object with some semantic metadata meaning about a data field.
+/// \note This method will throw an out-of-bounds exception for invalid indicator characters.
+- (instancetype)initWithRawValue:(char)rawValue;
+
+/// Create an indicator with the given raw value.
+/// \param value An ASCII space, lowercase letter, or number.
+/// \returns An indicator object with some semantic metadata meaning about a data field.
+/// \note This method will throw an out-of-bounds exception for invalid indicator characters.
+- (instancetype)initWithValue:(char)value NS_SWIFT_NAME(init(_:));
+
+/// Create an indicator with the given raw value.
+/// \param value An ASCII space, lowercase letter, or number.
+/// \returns An indicator object with some semantic metadata meaning about a data field.
+/// \note This method will throw an out-of-bounds exception for invalid indicator characters.
++ (instancetype)indicatorWithValue:(char)value NS_SWIFT_UNAVAILABLE("Use init(_:)");
+
+/// Create an indicator with the given raw value.
+/// \param rawValue An ASCII space, lowercase letter, or number.
+/// \returns An indicator object with some semantic metadata meaning about a data field.
+/// \note This method will throw an out-of-bounds exception for invalid indicator characters.
++ (instancetype)indicatorWithRawValue:(char)rawValue NS_SWIFT_UNAVAILABLE("Use init(rawValue:)");
+
+/// Use Objective-C subscript syntax to make an indicator value.
+///
+/// \code
+/// BibIndicator *ind = [BibIndicator self]['a'];
+/// \endcode
+///
+/// \param rawValue The ASCII space, lowercase letter, or number.
+/// \returns An indicator object with some semantic metadata meaning about a data field.
++ (instancetype)objectAtIndexedSubscript:(char)rawValue NS_SWIFT_UNAVAILABLE("Use literal syntax");
+
+/// Determine whether or not the given indicator has the same raw value as the receiver.
+///
+/// \param indicator The record field with which the receiver should be compared.
+/// \returns Returns \c YES if the given indicator and the receiver have the same raw value.
+- (BOOL)isEqualToIndicator:(BibFieldIndicator *)indicator;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Bibliotek/Record/RecordField/BibFieldIndicator.m
+++ b/Bibliotek/Record/RecordField/BibFieldIndicator.m
@@ -1,0 +1,135 @@
+//
+//  BibFieldIndicator.m
+//  Bibliotek
+//
+//  Created by Steve Brunwasser on 6/7/20.
+//  Copyright © 2020 Steve Brunwasser. All rights reserved.
+//
+
+#import "BibFieldIndicator.h"
+#import "Bibliotek+Internal.h"
+#import <objc/runtime.h>
+#import <objc/message.h>
+
+static size_t const BibIndicatorCount = 37;
+static size_t BibIndicatorInstanceSize;
+static void *BibIndicatorBuffer;
+
+__attribute__((always_inline))
+static inline size_t BibIndicatorGetCacheIndexForRawValue(char rawValue) {
+    if (rawValue == ' ') { return 0; }
+    if (rawValue >= '0' && rawValue <= '9') { return (rawValue - '0') + 1; }
+    if (rawValue >= 'a' && rawValue <= 'z') { return (rawValue - 'a') + 11; }
+    [NSException raise:NSRangeException format:@"Invalid indicator characher '%c'", rawValue];
+    return NSNotFound;
+}
+
+__attribute__((always_inline))
+static inline char BibIndicatorGetRawValueForCacheIndex(size_t index) {
+    if (index == 0) { return ' '; }
+    if (index >= 1 && index <= 10) { return '0' + (index - 1); }
+    if (index >= 11 && index <= 36) { return 'a' + (index - 11); }
+    [NSException raise:NSRangeException format:@"Cache index %zu is out of bounds", index];
+    return -1;
+}
+
+__attribute__((always_inline))
+static inline BibFieldIndicator *BibIndicatorGetCachedInstanceAtIndex(size_t index)  {
+    return BibIndicatorBuffer + (index * BibIndicatorInstanceSize);
+}
+
+@implementation BibFieldIndicator
+
+@synthesize rawValue = rawValue;
+
++ (BibFieldIndicator *)blank { return [BibFieldIndicator indicatorWithRawValue:' ']; }
+
++ (void)load {
+    BibIndicatorInstanceSize = class_getInstanceSize(self);
+    BibIndicatorBuffer = calloc(BibIndicatorCount, BibIndicatorInstanceSize);
+    for (size_t index = 0; index < BibIndicatorCount; index += 1) {
+        BibFieldIndicator *indicator = BibIndicatorGetCachedInstanceAtIndex(index);
+        objc_constructInstance(self, indicator);
+        struct objc_super _super = { indicator, [NSObject self] };
+        ((id(*)(struct objc_super *, SEL))objc_msgSendSuper)(&_super, @selector(init));
+        indicator->rawValue = BibIndicatorGetRawValueForCacheIndex(index);
+    }
+}
+
++ (instancetype)allocWithZone:(struct _NSZone *)zone {
+    return BibIndicatorGetCachedInstanceAtIndex(0);
+}
+
+- (instancetype)initWithRawValue:(char)rawValue {
+    size_t const index = BibIndicatorGetCacheIndexForRawValue((uint8_t)rawValue);
+    self = BibIndicatorGetCachedInstanceAtIndex(index);
+    NSParameterAssert(self != nil);
+    return self;
+}
+
++ (instancetype)indicatorWithRawValue:(char)rawValue {
+    size_t const index = BibIndicatorGetCacheIndexForRawValue((uint8_t)rawValue);
+    BibFieldIndicator *indicator = BibIndicatorGetCachedInstanceAtIndex(index);
+    NSParameterAssert(indicator != nil);
+    return indicator;
+}
+
+- (instancetype)initWithValue:(char)value { return [self initWithRawValue:value]; }
++ (instancetype)indicatorWithValue:(char)value { return [self indicatorWithRawValue:value]; }
+
++ (instancetype)objectAtIndexedSubscript:(char)rawValue {
+    return [self indicatorWithRawValue:rawValue];
+}
+
+- (instancetype)init {
+    return [self initWithRawValue:' '];
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
+- (void)dealloc {}
+#pragma clang diagnostic pop
+
+- (id)copyWithZone:(NSZone *)zone { return self; }
+
+#pragma mark - NSCoding
+
++ (BOOL)supportsSecureCoding { return YES; }
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+    char const rawValue = (char)[coder decodeIntForKey:BibKey(rawValue)];
+    return [self initWithRawValue:rawValue];
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+    [coder encodeInt:(int)(self->rawValue) forKey:BibKey(rawValue)];
+}
+
+#pragma mark - Equality
+
+- (BOOL)isEqualToIndicator:(BibFieldIndicator *)indicator {
+    return self == indicator
+        || (self->rawValue == indicator->rawValue);
+}
+
+- (BOOL)isEqual:(id)object {
+    return (self == object)
+        || ([object isKindOfClass:[BibFieldIndicator self]] && [self isEqual:object]);
+}
+
+- (NSUInteger)hash {
+    return (NSUInteger)self->rawValue;
+}
+
+#pragma mark - Description
+
+- (NSString *)description {
+    return (self->rawValue == ' ') ? @"\u2422" : [NSString stringWithFormat:@"%c", self->rawValue];
+}
+
+- (NSString *)debugDescription {
+    return [NSString stringWithFormat:@"<BibFieldIndicator rawValue='%c', %#04X; '%@'>",
+                                      self->rawValue, self->rawValue, [self description]];
+}
+
+@end

--- a/Bibliotek/Record/RecordField/BibFieldIndicator.m
+++ b/Bibliotek/Record/RecordField/BibFieldIndicator.m
@@ -82,13 +82,6 @@ static inline BibFieldIndicator *BibIndicatorGetCachedInstanceAtIndex(size_t ind
     }
 }
 
-- (instancetype)initWithValue:(char)value { return [self initWithRawValue:value]; }
-+ (instancetype)indicatorWithValue:(char)value { return [self indicatorWithRawValue:value]; }
-
-+ (instancetype)objectAtIndexedSubscript:(char)rawValue {
-    return [self indicatorWithRawValue:rawValue];
-}
-
 - (instancetype)init {
     return [self initWithRawValue:' '];
 }
@@ -100,6 +93,10 @@ static inline BibFieldIndicator *BibIndicatorGetCachedInstanceAtIndex(size_t ind
 }
 
 - (id)copyWithZone:(NSZone *)zone { return self; }
+
++ (instancetype)objectAtIndexedSubscript:(char)rawValue {
+    return [self indicatorWithRawValue:rawValue];
+}
 
 #pragma mark - NSCoding
 

--- a/Bibliotek/Record/RecordField/BibFieldIndicator.m
+++ b/Bibliotek/Record/RecordField/BibFieldIndicator.m
@@ -57,21 +57,29 @@ static inline BibFieldIndicator *BibIndicatorGetCachedInstanceAtIndex(size_t ind
 }
 
 + (instancetype)allocWithZone:(struct _NSZone *)zone {
-    return BibIndicatorGetCachedInstanceAtIndex(0);
+    return (self == [BibFieldIndicator self]) ? BibIndicatorGetCachedInstanceAtIndex(0) : [super allocWithZone:zone];
 }
 
 - (instancetype)initWithRawValue:(char)rawValue {
-    size_t const index = BibIndicatorGetCacheIndexForRawValue((uint8_t)rawValue);
-    self = BibIndicatorGetCachedInstanceAtIndex(index);
-    NSParameterAssert(self != nil);
+    if ([self class] == [BibFieldIndicator self]) {
+        size_t const index = BibIndicatorGetCacheIndexForRawValue((uint8_t)rawValue);
+        self = BibIndicatorGetCachedInstanceAtIndex(index);
+        NSParameterAssert(self != nil);
+    } else if (self = [super init]) {
+        self->rawValue = rawValue;
+    }
     return self;
 }
 
 + (instancetype)indicatorWithRawValue:(char)rawValue {
-    size_t const index = BibIndicatorGetCacheIndexForRawValue((uint8_t)rawValue);
-    BibFieldIndicator *indicator = BibIndicatorGetCachedInstanceAtIndex(index);
-    NSParameterAssert(indicator != nil);
-    return indicator;
+    if (self == [BibFieldIndicator self]) {
+        size_t const index = BibIndicatorGetCacheIndexForRawValue((uint8_t)rawValue);
+        BibFieldIndicator *indicator = BibIndicatorGetCachedInstanceAtIndex(index);
+        NSParameterAssert(indicator != nil);
+        return indicator;
+    } else {
+        return [[BibFieldIndicator alloc] initWithRawValue:rawValue];
+    }
 }
 
 - (instancetype)initWithValue:(char)value { return [self initWithRawValue:value]; }
@@ -85,10 +93,11 @@ static inline BibFieldIndicator *BibIndicatorGetCachedInstanceAtIndex(size_t ind
     return [self initWithRawValue:' '];
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wobjc-missing-super-calls"
-- (void)dealloc {}
-#pragma clang diagnostic pop
+- (void)dealloc {
+    if ([self class] != [BibFieldIndicator self]) {
+        [super dealloc];
+    }
+}
 
 - (id)copyWithZone:(NSZone *)zone { return self; }
 
@@ -127,9 +136,11 @@ static inline BibFieldIndicator *BibIndicatorGetCachedInstanceAtIndex(size_t ind
     return (self->rawValue == ' ') ? @"\u2422" : [NSString stringWithFormat:@"%c", self->rawValue];
 }
 
+#if DEBUG
 - (NSString *)debugDescription {
     return [NSString stringWithFormat:@"<BibFieldIndicator rawValue='%c', %#04X; '%@'>",
                                       self->rawValue, self->rawValue, [self description]];
 }
+#endif
 
 @end

--- a/Bibliotek/Record/RecordField/BibRecordField.h
+++ b/Bibliotek/Record/RecordField/BibRecordField.h
@@ -88,8 +88,18 @@ NS_ASSUME_NONNULL_BEGIN
 /// \returns An empty record field object.
 - (instancetype)initWithFieldTag:(BibFieldTag *)fieldTag NS_DESIGNATED_INITIALIZER;
 
+/// Create an empty record field with the given record field tag.
+/// \param fieldTag The field tag identifying the semantic purpose for the new record field.
+/// \param controlValue The control value for the field.
+/// \returns An control field object.
 - (instancetype)initWithFieldTag:(BibFieldTag *)fieldTag controlValue:(NSString *)controlValue;
 
+/// Create an empty record field with the given record field tag.
+/// \param fieldTag The field tag identifying the semantic purpose for the new record field.
+/// \param firstIndicator The first indicator value for a data field.
+/// \param secondIndicator The second indicator value for a data field.
+/// \param subfields A list of subfields for a data field.
+/// \returns A data field object.
 - (instancetype)initWithFieldTag:(BibFieldTag *)fieldTag
                   firstIndicator:(BibFieldIndicator *)firstIndicator
                  secondIndicator:(BibFieldIndicator *)secondIndicator

--- a/Bibliotek/Record/RecordField/BibRecordField.h
+++ b/Bibliotek/Record/RecordField/BibRecordField.h
@@ -1,0 +1,180 @@
+//
+//  BibRecordField.h
+//  Bibliotek
+//
+//  Created by Steve Brunwasser on 5/31/20.
+//  Copyright © 2020 Steve Brunwasser. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class BibFieldIndicator;
+@class BibFieldTag;
+@class BibSubfield;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A set of information and/or metadata about the item represented by a MARC record.
+///
+/// The semantic meaning of a record field is indicated by its \c fieldTag value.
+/// A control field contains information and metadata about how a record's content should be processed.
+///
+/// The semantic meaning of a data field is indicated by its \c fieldTag value, and its indicators are used as flags
+/// that determine how the data in its subfields should be interpreted or displayed.
+///
+/// Data fields are composed of \c subfields, which are portions of data semantically identified by their \c code.
+/// The interpretation of data within a content field is often determined by the formatting of its subfields' contents.
+/// For example, a bibliographic record's title statement, identified with the tag \c 245, formats its content using
+/// ISBD principles and uses subfield codes to semantically tag each piece of the full statement.
+///
+/// You can read more about ISBD on its Wikipedia page:
+/// https://en.wikipedia.org/wiki/International_Standard_Bibliographic_Description
+///
+/// The ISBD punctuation standard can be found in section A3 in this consolidated technical specification:
+/// https://www.ifla.org/files/assets/cataloguing/isbd/isbd-cons_20110321.pdf
+///
+/// More information about MARC 21 records can be found in the Library of Congress's documentation on
+/// MARC 21 Record Structure: https://www.loc.gov/marc/specifications/specrecstruc.html
+@interface BibRecordField : NSObject <NSCopying, NSMutableCopying>
+
+/// A value indicating the semantic purpose of the record field.
+@property (nonatomic, readonly, strong) BibFieldTag *fieldTag;
+
+/// The information contained within the control field.
+///
+/// \note This value is \c nil for data fields.
+/// \note This value is never \c nil for control fields.
+///       Setting it to \c nil will change its value to the empty string.
+@property (nonatomic, readonly, copy, nullable) NSString *controlValue;
+
+/// The first metadata value in a data field, which can identify some semantic meaning to the field as a whole.
+///
+/// \note This value is \c nil for control fields.
+/// \note This value is never \c nil for data fields.
+///       Setting it to \c nil will change its value to the blank indicator.
+@property (nonatomic, readonly, copy, nullable) BibFieldIndicator *firstIndicator;
+
+/// The second metadata value in a data field, which can identify some semantic meaning to the field as a whole.
+///
+/// \note This value is \c nil for control fields.
+/// \note This value is never \c nil for data fields.
+///       Setting it to \c nil will change its value to the blank indicator.
+@property (nonatomic, readonly, copy, nullable) BibFieldIndicator *secondIndicator;
+
+/// An ordered list of subfields containing portions of data semantically identified by their \c code.
+/// The interpretation of data within a content field is often determined by the formatting of its subfields' contents.
+/// For example, a bibliographic record's title statement, identified with the tag \c 245, formats its content using
+/// ISBD principles and uses subfield codes to semantically tag each piece of the full statement.
+///
+/// You can read more about ISBD on its Wikipedia page:
+/// https://en.wikipedia.org/wiki/International_Standard_Bibliographic_Description
+///
+/// The ISBD punctuation standard can be found in section A3 in this consolidated technical specification:
+/// https://www.ifla.org/files/assets/cataloguing/isbd/isbd-cons_20110321.pdf
+///
+/// \note This value is \c nil for control fields.
+/// \note This value is never \c nil for data fields.
+///       Setting it to \c nil will change its value to an empty array.
+@property (nonatomic, readonly, copy, nullable) NSArray<BibSubfield *> *subfields;
+
+/// This object is a control field containing a control value.
+@property (nonatomic, readonly) BOOL isControlField;
+
+/// This object is a data field with contnet indicators and subfield data.
+@property (nonatomic, readonly) BOOL isDataField;
+
+/// Create an empty record field with the given record field tag.
+/// \param fieldTag The field tag identifying the semantic purpose for the new record field.
+/// \returns An empty record field object.
+- (instancetype)initWithFieldTag:(BibFieldTag *)fieldTag NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithFieldTag:(BibFieldTag *)fieldTag controlValue:(NSString *)controlValue;
+
+- (instancetype)initWithFieldTag:(BibFieldTag *)fieldTag
+                  firstIndicator:(BibFieldIndicator *)firstIndicator
+                 secondIndicator:(BibFieldIndicator *)secondIndicator
+                       subfields:(NSArray<BibSubfield *> *)subfields;
+
+@end
+
+@interface BibRecordField (SubfieldAccess)
+
+@property (nonatomic, readonly) NSUInteger subfieldCount;
+
+- (BibSubfield *)subfieldAtIndex:(NSUInteger)index;
+- (BibSubfield *)objectAtIndexedSubscript:(NSUInteger)index;
+
+@end
+
+@interface BibRecordField (Equality)
+
+/// Determine whether or not the given record field represents the same data as the receiver.
+///
+/// \param recordField The record field with which the receiver should be compared.
+/// \returns Returns \c YES if the given record field and the receiver have the same field tag and semantic value.
+- (BOOL)isEqualToRecordField:(BibRecordField *)recordField;
+
+@end
+
+@interface BibRecordField (Serialization) <NSSecureCoding>
+@end
+
+#pragma mark - Mutable
+
+@interface BibMutableRecordField : BibRecordField
+
+/// A value indicating the semantic purpose of the record field.
+@property (nonatomic, readwrite, strong) BibFieldTag *fieldTag;
+
+/// The information contained within the control field.
+///
+/// \note This value is \c nil for data fields.
+/// \note This value is never \c nil for control fields.
+///       Setting it to \c nil will change its value to the empty string.
+@property (nonatomic, readwrite, copy, nullable) NSString *controlValue;
+
+/// The first metadata value in a data field, which can identify some semantic meaning to the field as a whole.
+///
+/// \note This value is \c nil for control fields.
+/// \note This value is never \c nil for data fields.
+///       Setting it to \c nil will change its value to the blank indicator.
+@property (nonatomic, readwrite, copy, nullable) BibFieldIndicator *firstIndicator;
+
+/// The second metadata value in a data field, which can identify some semantic meaning to the field as a whole.
+///
+/// \note This value is \c nil for control fields.
+/// \note This value is never \c nil for data fields.
+///       Setting it to \c nil will change its value to the blank indicator.
+@property (nonatomic, readwrite, copy, nullable) BibFieldIndicator *secondIndicator;
+
+/// An ordered list of subfields containing portions of data semantically identified by their \c code.
+/// The interpretation of data within a content field is often determined by the formatting of its subfields' contents.
+/// For example, a bibliographic record's title statement, identified with the tag \c 245, formats its content using
+/// ISBD principles and uses subfield codes to semantically tag each piece of the full statement.
+///
+/// You can read more about ISBD on its Wikipedia page:
+/// https://en.wikipedia.org/wiki/International_Standard_Bibliographic_Description
+///
+/// The ISBD punctuation standard can be found in section A3 in this consolidated technical specification:
+/// https://www.ifla.org/files/assets/cataloguing/isbd/isbd-cons_20110321.pdf
+///
+/// \note This value is \c nil for control fields.
+/// \note This value is never \c nil for data fields.
+///       Setting it to \c nil will change its value to an empty array.
+@property (nonatomic, readwrite, copy, nullable) NSArray<BibSubfield *> *subfields;
+
+@end
+
+@interface BibMutableRecordField (SubfieldAccess)
+
+- (void)addSubfield:(BibSubfield *)subfield;
+- (void)removeSubfield:(BibSubfield *)subfield;
+- (void)insertSubfield:(BibSubfield *)subfield atIndex:(NSUInteger)index;
+- (void)replaceSubfieldAtIndex:(NSUInteger)index withSubfield:(BibSubfield *)subfield;
+
+- (void)setSubfield:(BibSubfield *)subfield atIndex:(NSUInteger)index;
+- (void)setObject:(BibSubfield *)subfield atIndexedSubscript:(NSUInteger)index;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Bibliotek/Record/RecordField/BibRecordField.h
+++ b/Bibliotek/Record/RecordField/BibRecordField.h
@@ -110,13 +110,41 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface BibRecordField (SubfieldAccess)
 
+/// The total amount of subfields contained in this data field.
+/// \note This values is always \c 0 for control fields.
 @property (nonatomic, readonly) NSUInteger subfieldCount;
 
+/// Get this data field's subfield at the given index.
+/// \param index The index of the subfield to access.
+/// \returns This data field's subfiled located at the given index.
+/// \note This method will throw an \c NSSRangeException for control fields.
 - (BibSubfield *)subfieldAtIndex:(NSUInteger)index;
+
+/// Use indexed subscripting syntax to access a subfield from this data field.
+/// \param index The index of the subfield to access.
+/// \returns This data field's subfiled located at the given index.
+/// \note This method will throw an \c NSSRangeException for control fields.
 - (BibSubfield *)objectAtIndexedSubscript:(NSUInteger)index;
 
+/// Get the first subfield marked with the given code.
+/// \param subfieldCode The subfield code that the resulting subfield should have.
+/// \returns The first subfield in this data field with the given subfield code.
+///          \c nil is returned if there is no such matching subfield.
+/// \note This method always returns \c nil for control fields.
 - (nullable BibSubfield *)subfieldWithCode:(BibSubfieldCode)subfieldCode;
+
+/// Get the index of the first subfield marked with the given code.
+/// \param subfieldCode The subfield code that the resulting subfield should have.
+/// \returns The index of the first subfield in this data field with the given subfield code.
+///          \c NSNotFound is returned if there is no such matching subfield.
+/// \note This method always returns \c NSNotFound for control fields.
 - (NSUInteger)indexOfSubfieldWithCode:(BibSubfieldCode)subfieldCode;
+
+/// Check to see if this data field has a subfield marked with the given code.
+/// \param subfieldCode The subfield code used to check the presence of any relevant subfields.
+/// \returns \c YES when this data field contains a subfield marked with the given code.
+///          \c NO is returned when no such subfield is found.
+/// \note This method always returns \c NO for control fields.
 - (BOOL)containsSubfieldWithCode:(BibSubfieldCode)subfieldCode;
 
 @end

--- a/Bibliotek/Record/RecordField/BibRecordField.h
+++ b/Bibliotek/Record/RecordField/BibRecordField.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <Bibliotek/BibSubfield.h>
 
 @class BibFieldIndicator;
 @class BibFieldTag;
@@ -113,6 +114,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BibSubfield *)subfieldAtIndex:(NSUInteger)index;
 - (BibSubfield *)objectAtIndexedSubscript:(NSUInteger)index;
+
+- (nullable BibSubfield *)subfieldWithCode:(BibSubfieldCode)subfieldCode;
+- (NSUInteger)indexOfSubfieldWithCode:(BibSubfieldCode)subfieldCode;
+- (BOOL)containsSubfieldWithCode:(BibSubfieldCode)subfieldCode;
 
 @end
 

--- a/Bibliotek/Record/RecordField/BibRecordField.h
+++ b/Bibliotek/Record/RecordField/BibRecordField.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// The semantic meaning of a data field is indicated by its \c fieldTag value, and its indicators are used as flags
 /// that determine how the data in its subfields should be interpreted or displayed.
 ///
-/// Data fields are composed of \c subfields, which are portions of data semantically identified by their \c code.
+/// Data fields are composed of \c subfields, which are portions of data semantically identified by their \c subfieldCode.
 /// The interpretation of data within a content field is often determined by the formatting of its subfields' contents.
 /// For example, a bibliographic record's title statement, identified with the tag \c 245, formats its content using
 /// ISBD principles and uses subfield codes to semantically tag each piece of the full statement.
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///       Setting it to \c nil will change its value to the blank indicator.
 @property (nonatomic, readonly, copy, nullable) BibFieldIndicator *secondIndicator;
 
-/// An ordered list of subfields containing portions of data semantically identified by their \c code.
+/// An ordered list of subfields containing portions of data semantically identified by their \c subfieldCode.
 /// The interpretation of data within a content field is often determined by the formatting of its subfields' contents.
 /// For example, a bibliographic record's title statement, identified with the tag \c 245, formats its content using
 /// ISBD principles and uses subfield codes to semantically tag each piece of the full statement.
@@ -157,7 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///       Setting it to \c nil will change its value to the blank indicator.
 @property (nonatomic, readwrite, copy, nullable) BibFieldIndicator *secondIndicator;
 
-/// An ordered list of subfields containing portions of data semantically identified by their \c code.
+/// An ordered list of subfields containing portions of data semantically identified by their \c subfieldCode.
 /// The interpretation of data within a content field is often determined by the formatting of its subfields' contents.
 /// For example, a bibliographic record's title statement, identified with the tag \c 245, formats its content using
 /// ISBD principles and uses subfield codes to semantically tag each piece of the full statement.

--- a/Bibliotek/Record/RecordField/BibRecordField.m
+++ b/Bibliotek/Record/RecordField/BibRecordField.m
@@ -154,6 +154,31 @@
     }
 }
 
+- (NSString *)description {
+    if (self.isDataField) {
+        return [[self.subfields valueForKey:BibKey(description)] componentsJoinedByString:@" "];
+
+    } else if (self.isControlField) {
+        return self.controlValue;
+
+    } else {
+        return @"";
+    }
+}
+
+- (NSString *)debugDescription {
+    if (self.isDataField) {
+        NSString *const content = [[self.subfields valueForKey:BibKey(debugDescription)] componentsJoinedByString:@""];
+        return [NSString stringWithFormat:@"%@ %@%@ %@",
+                                          self.fieldTag, self.firstIndicator, self.secondIndicator, content];
+    } else if (self.isControlField) {
+        return [NSString stringWithFormat:@"%@ %@", self.fieldTag, self.controlValue];
+
+    } else {
+        return self.firstIndicator.description;
+    }
+}
+
 @end
 
 @implementation BibRecordField (SubfieldAccess)

--- a/Bibliotek/Record/RecordField/BibRecordField.m
+++ b/Bibliotek/Record/RecordField/BibRecordField.m
@@ -187,6 +187,26 @@
 - (BibSubfield *)subfieldAtIndex:(NSUInteger)index { return [self.subfields objectAtIndex:index]; }
 - (BibSubfield *)objectAtIndexedSubscript:(NSUInteger)index { return [self subfieldAtIndex:index]; }
 
+- (NSUInteger)indexOfSubfieldWithCode:(BibSubfieldCode)subfieldCode {
+    NSArray *const subfields = self.subfields;
+    NSUInteger const count = subfields.count;
+    for (NSUInteger index = 0; index < count; index += 1) {
+        if ([[[subfields objectAtIndex:index] subfieldCode] isEqualToString:subfieldCode]) {
+            return index;
+        }
+    }
+    return NSNotFound;
+}
+
+- (BibSubfield *)subfieldWithCode:(BibSubfieldCode)subfieldCode {
+    NSUInteger const index = [self indexOfSubfieldWithCode:subfieldCode];
+    return (index == NSNotFound) ? nil : [self subfieldAtIndex:index];
+}
+
+- (BOOL)containsSubfieldWithCode:(BibSubfieldCode)subfieldCode {
+    return [self indexOfSubfieldWithCode:subfieldCode] != NSNotFound;
+}
+
 @end
 
 @implementation BibRecordField (Equality)
@@ -267,6 +287,9 @@
 
 - (NSUInteger)subfieldCount { return 0; }
 - (BibSubfield *)subfieldAtIndex:(NSUInteger)index { return [[NSArray new] objectAtIndex:index]; }
+- (NSUInteger)indexOfSubfieldWithCode:(BibSubfieldCode)subfieldCode { return NSNotFound; }
+- (BibSubfield *)subfieldWithCode:(BibSubfieldCode)subfieldCode { return nil; }
+- (BOOL)containsSubfieldWithCode:(BibSubfieldCode)subfieldCode { return NO; }
 
 - (Class)classForCoder { return [BibRecordField self]; }
 
@@ -299,6 +322,9 @@
 
 - (NSUInteger)subfieldCount { return 0; }
 - (BibSubfield *)subfieldAtIndex:(NSUInteger)index { return [[NSArray new] objectAtIndex:index]; }
+- (NSUInteger)indexOfSubfieldWithCode:(BibSubfieldCode)subfieldCode { return NSNotFound; }
+- (BibSubfield *)subfieldWithCode:(BibSubfieldCode)subfieldCode { return nil; }
+- (BOOL)containsSubfieldWithCode:(BibSubfieldCode)subfieldCode { return NO; }
 
 - (Class)classForCoder { return [BibRecordField self]; }
 
@@ -417,6 +443,9 @@
 
 - (NSUInteger)subfieldCount { return 0; }
 - (BibSubfield *)subfieldAtIndex:(NSUInteger)index { return [[NSArray new] objectAtIndex:index]; }
+- (NSUInteger)indexOfSubfieldWithCode:(BibSubfieldCode)subfieldCode { return NSNotFound; }
+- (BibSubfield *)subfieldWithCode:(BibSubfieldCode)subfieldCode { return nil; }
+- (BOOL)containsSubfieldWithCode:(BibSubfieldCode)subfieldCode { return NO; }
 
 - (void)setFieldTag:(BibFieldTag *)fieldTag {
     if (_fieldTag != fieldTag) {
@@ -495,6 +524,9 @@
 
 - (NSUInteger)subfieldCount { return 0; }
 - (BibSubfield *)subfieldAtIndex:(NSUInteger)index { return [[NSArray new] objectAtIndex:index]; }
+- (NSUInteger)indexOfSubfieldWithCode:(BibSubfieldCode)subfieldCode { return NSNotFound; }
+- (BibSubfield *)subfieldWithCode:(BibSubfieldCode)subfieldCode { return nil; }
+- (BOOL)containsSubfieldWithCode:(BibSubfieldCode)subfieldCode { return NO; }
 
 - (void)setFieldTag:(BibFieldTag *)fieldTag {
     if (_fieldTag != fieldTag) {

--- a/Bibliotek/Record/RecordField/BibRecordField.m
+++ b/Bibliotek/Record/RecordField/BibRecordField.m
@@ -1,0 +1,502 @@
+//
+//  BibRecordField.m
+//  Bibliotek
+//
+//  Created by Steve Brunwasser on 5/31/20.
+//  Copyright © 2020 Steve Brunwasser. All rights reserved.
+//
+
+#import "BibRecordField.h"
+#import "BibFieldTag.h"
+#import "BibFieldIndicator.h"
+#import "Bibliotek+Internal.h"
+#import "BibHasher.h"
+#import <objc/runtime.h>
+
+@interface _BibRecordNofield : BibRecordField
+@end
+
+@interface _BibRecordDatafield : BibRecordField
+@end
+
+@interface _BibRecordControlfield : BibRecordField
+@end
+
+@interface _BibMutableRecordNofield : BibMutableRecordField
+@end
+
+@interface _BibMutableRecordDatafield : BibMutableRecordField
+@end
+
+@interface _BibMutableRecordControlfield : BibMutableRecordField
+@end
+
+#pragma mark - Field
+
+@implementation BibRecordField {
+@public
+    BibFieldTag *_fieldTag;
+    NSString *_controlValue;
+    BibFieldIndicator *_firstIndicator;
+    BibFieldIndicator *_secondIndicator;
+    NSMutableArray<BibSubfield *> *_subfields;
+}
+
+@synthesize fieldTag = _fieldTag;
+@synthesize controlValue = _controlValue;
+@synthesize firstIndicator = _firstIndicator;
+@synthesize secondIndicator = _secondIndicator;
+@synthesize subfields = _subfields;
+
+- (instancetype)init {
+    return [self initWithFieldTag:[BibFieldTag new]];
+}
+
+- (instancetype)initWithFieldTag:(BibFieldTag *)fieldTag {
+    if (fieldTag == nil) {
+        return nil;
+    }
+    if (self = [super init]) {
+        _fieldTag = [fieldTag copy];
+        if ([self class] == [BibRecordField self]) {
+            if ([_fieldTag isControlTag]) {
+                _controlValue = @"";
+                object_setClass(self, [_BibRecordControlfield self]);
+            } else if ([_fieldTag isDataTag]) {
+                _subfields = [NSMutableArray new];
+                object_setClass(self, [_BibRecordDatafield self]);
+            } else {
+                object_setClass(self, [_BibRecordNofield self]);
+            }
+        } else if ([self class] == [BibMutableRecordField self]) {
+            if ([_fieldTag isControlTag]) {
+                object_setClass(self, [_BibMutableRecordControlfield self]);
+            } else if ([_fieldTag isDataTag]) {
+                object_setClass(self, [_BibMutableRecordDatafield self]);
+            } else {
+                object_setClass(self, [_BibMutableRecordNofield self]);
+            }
+        }
+    }
+    return self;
+}
+
+- (instancetype)initWithFieldTag:(BibFieldTag *)fieldTag controlValue:(NSString *)controlValue {
+    NSParameterAssert(fieldTag.isControlTag);
+    if (self = [self initWithFieldTag:fieldTag]) {
+        _controlValue = [controlValue copy];
+    }
+    return self;
+}
+
+- (instancetype)initWithFieldTag:(BibFieldTag *)fieldTag
+                  firstIndicator:(BibFieldIndicator *)firstIndicator
+                 secondIndicator:(BibFieldIndicator *)secondIndicator
+                       subfields:(NSArray<BibSubfield *> *)subfields {
+    NSParameterAssert(fieldTag.isDataTag);
+    if (self = [self initWithFieldTag:fieldTag]) {
+        _firstIndicator = [firstIndicator copy];
+        _secondIndicator = [secondIndicator copy];
+        _subfields = [subfields mutableCopy];
+    }
+    return self;
+}
+
+- (NSString *)controlValue { return [self isControlField] ? (_controlValue ?: @"") : nil; }
+
+- (BibFieldIndicator *)firstIndicator { return [self isDataField] ? (_firstIndicator ?: [BibFieldIndicator new]) : nil; }
+- (BibFieldIndicator *)secondIndicator { return [self isDataField] ? (_secondIndicator ?: [BibFieldIndicator new]) : nil; }
+- (NSArray<BibSubfield *> *)subfields { return [self isDataField] ? ([_subfields copy] ?: [NSArray new]) : nil; }
+
+- (BOOL)isControlField { return [[self fieldTag] isControlTag]; }
+- (BOOL)isDataField { return [[self fieldTag] isDataTag]; }
+
++ (NSSet *)keyPathsForValuesAffectingControlValue { return [NSSet setWithObject:BibKeyPath(fieldTag)]; }
++ (NSSet *)keyPathsForValuesAffectingFirstIndicator { return [NSSet setWithObject:BibKeyPath(fieldTag)]; }
++ (NSSet *)keyPathsForValuesAffectingSecondIndicator { return [NSSet setWithObject:BibKeyPath(fieldTag)]; }
++ (NSSet *)keyPathsForValuesAffectingSubfields { return [NSSet setWithObject:BibKeyPath(fieldTag)]; }
++ (NSSet *)keyPathsForValuesAffectingIsControlfield { return [NSSet setWithObject:BibKeyPath(fieldTag)]; }
++ (NSSet *)keyPathsForValuesAffectingIsDatafield { return [NSSet setWithObject:BibKeyPath(fieldTag)]; }
+
+- (id)copyWithZone:(NSZone *)zone {
+    if ([self isDataField]) {
+        _BibRecordDatafield *const copy = [_BibRecordDatafield new];
+        copy->_fieldTag = [[self fieldTag] copy];
+        copy->_firstIndicator = [[self firstIndicator] copy];
+        copy->_secondIndicator = [[self secondIndicator] copy];
+        copy->_subfields = [[self subfields] mutableCopy] ?: [NSMutableArray new];
+        return copy;
+    } else if ([self isControlField]) {
+        _BibRecordControlfield *const copy = [_BibRecordControlfield new];
+        copy->_fieldTag = [[self fieldTag] copy];
+        copy->_controlValue = [[self controlValue] copy];
+        return copy;
+    } else {
+        return [_BibRecordNofield new];
+    }
+}
+
+- (id)mutableCopyWithZone:(NSZone *)zone {
+    if ([self isDataField]) {
+        _BibMutableRecordDatafield *const mutableCopy = [_BibMutableRecordDatafield new];
+        mutableCopy->_fieldTag = [[self fieldTag] copy];
+        mutableCopy->_firstIndicator = [[self firstIndicator] copy];
+        mutableCopy->_secondIndicator = [[self secondIndicator] copy];
+        mutableCopy->_subfields = [[self subfields] mutableCopy] ?: [NSMutableArray new];
+        return mutableCopy;
+    } else if ([self isControlField]) {
+        _BibMutableRecordControlfield *const mutableCopy = [_BibMutableRecordControlfield new];
+        mutableCopy->_fieldTag = [[self fieldTag] copy];
+        mutableCopy->_controlValue = [[self controlValue] copy];
+        return mutableCopy;
+    } else {
+        return [_BibMutableRecordNofield new];
+    }
+}
+
+@end
+
+@implementation BibRecordField (SubfieldAccess)
+
+- (NSUInteger)subfieldCount { return self.subfields.count; }
+- (BibSubfield *)subfieldAtIndex:(NSUInteger)index { return [self.subfields objectAtIndex:index]; }
+- (BibSubfield *)objectAtIndexedSubscript:(NSUInteger)index { return [self subfieldAtIndex:index]; }
+
+@end
+
+@implementation BibRecordField (Equality)
+
+- (BOOL)isEqualToRecordField:(BibRecordField *)recordField {
+    return (self == recordField)
+        || ((recordField != nil)
+            && [[self fieldTag] isEqualToTag:[recordField fieldTag]]
+            && (![self isControlField] || [[self controlValue] isEqualToString:[recordField controlValue]])
+            && (![self isDataField] || ([[self firstIndicator] isEqualToIndicator:[recordField firstIndicator]]
+                                        && [[self secondIndicator] isEqualToIndicator:[recordField secondIndicator]]
+                                        && [[self subfields] isEqualToArray:[recordField subfields]])));
+}
+
+- (BOOL)isEqual:(id)object {
+    return (self == object)
+        || ((object != nil)
+            && ([object isKindOfClass:[BibRecordField self]] && [self isEqualToRecordField:object]));
+}
+
+- (NSUInteger)hash {
+    BibHasher *const hasher = [BibHasher new];
+    [hasher combineWithObject:[self fieldTag]];
+    if ([self isDataField]) {
+        [hasher combineWithObject:[self firstIndicator]];
+        [hasher combineWithObject:[self secondIndicator]];
+        [hasher combineWithObject:[self subfields]];
+    } else if ([self isControlField]) {
+        [hasher combineWithObject:[self controlValue]];
+    }
+    return [hasher hash];
+}
+
+@end
+
+@implementation BibRecordField (Serialization)
+
++ (BOOL)supportsSecureCoding { return YES; }
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+    BibFieldTag *const fieldTag = [coder decodeObjectOfClass:[BibFieldTag self] forKey:BibKey(fieldTag)];
+    if (self = [self initWithFieldTag:fieldTag]) {
+        if ([_fieldTag isControlTag]) {
+            _controlValue = [coder decodeObjectOfClass:[NSString self] forKey:BibKey(controlValue)];
+        } else if ([_fieldTag isDataTag]) {
+            _firstIndicator = [coder decodeObjectOfClass:[BibFieldIndicator self] forKey:BibKey(firstIndicator)];
+            _secondIndicator = [coder decodeObjectOfClass:[BibFieldIndicator self] forKey:BibKey(secondIndicator)];
+            _subfields = [coder decodeObjectOfClass:[NSArray self] forKey:BibKey(subfields)];
+        }
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)coder {
+    [coder encodeObject:[self fieldTag] forKey:BibKey(fieldTag)];
+    BibFieldTag *const fieldTag = [self fieldTag];
+    if ([fieldTag isControlTag]) {
+        [coder encodeObject:[self controlValue] forKey:BibKey(controlValue)];
+    } else if ([fieldTag isDataTag]) {
+        [coder encodeObject:[self firstIndicator] forKey:BibKey(firstIndicator)];
+        [coder encodeObject:[self secondIndicator] forKey:BibKey(secondIndicator)];
+        [coder encodeObject:[self subfields] forKey:BibKey(subfields)];
+    }
+}
+
+@end
+
+#pragma mark - Field Specialization
+
+@implementation _BibRecordNofield
+
+- (BOOL)isControlField { return NO; }
+- (BOOL)isDataField { return NO; }
+- (NSString *)controlValue { return nil; }
+- (BibFieldIndicator *)firstIndicator { return nil; }
+- (BibFieldIndicator *)secondIndicator { return nil; }
+- (NSArray<BibSubfield *> *)subfields { return nil; }
+
+- (NSUInteger)subfieldCount { return 0; }
+- (BibSubfield *)subfieldAtIndex:(NSUInteger)index { return [[NSArray new] objectAtIndex:index]; }
+
+- (Class)classForCoder { return [BibRecordField self]; }
+
+@end
+
+@implementation _BibRecordDatafield
+
+- (BOOL)isControlField { return NO; }
+- (BOOL)isDataField { return YES; }
+- (NSString *)controlValue { return nil; }
+- (BibFieldIndicator *)firstIndicator { return _firstIndicator; }
+- (BibFieldIndicator *)secondIndicator { return _secondIndicator; }
+- (NSArray<BibSubfield *> *)subfields { return [_subfields copy] ?: [NSArray array]; }
+
+- (NSUInteger)subfieldCount { return _subfields.count; }
+- (BibSubfield *)subfieldAtIndex:(NSUInteger)index { return [_subfields objectAtIndex:index]; }
+
+- (Class)classForCoder { return [BibRecordField self]; }
+
+@end
+
+@implementation _BibRecordControlfield
+
+- (BOOL)isControlField { return YES; }
+- (BOOL)isDataField { return NO; }
+- (NSString *)controlValue { return (_controlValue ?: @""); }
+- (BibFieldIndicator *)firstIndicator { return nil; }
+- (BibFieldIndicator *)secondIndicator { return nil; }
+- (NSArray<BibSubfield *> *)subfields { return nil; }
+
+- (NSUInteger)subfieldCount { return 0; }
+- (BibSubfield *)subfieldAtIndex:(NSUInteger)index { return [[NSArray new] objectAtIndex:index]; }
+
+- (Class)classForCoder { return [BibRecordField self]; }
+
+@end
+
+#pragma mark - Mutable Field
+
+@implementation BibMutableRecordField
+
+@dynamic fieldTag;
+@dynamic controlValue;
+@dynamic firstIndicator;
+@dynamic secondIndicator;
+@dynamic subfields;
+
+- (Class)classForCoder { return [BibRecordField self]; }
+
++ (BOOL)automaticallyNotifiesObserversOfFieldTag { return NO; }
++ (BOOL)automaticallyNotifiesObserversOfControlValue { return NO; }
++ (BOOL)automaticallyNotifiesObserversOfFirstIndicator { return NO; }
++ (BOOL)automaticallyNotifiesObserversOfSecondIndicator { return NO; }
++ (BOOL)automaticallyNotifiesObserversOfSubfields { return NO; }
+
+- (void)setFieldTag:(BibFieldTag *)fieldTag {
+    if (_fieldTag != fieldTag) {
+        [self willChangeValueForKey:BibKey(fieldTag)];
+        _fieldTag = [fieldTag copy];
+        [self didChangeValueForKey:BibKey(fieldTag)];
+    }
+}
+
+- (void)setControlValue:(NSString *)controlValue {
+    if (_controlValue != controlValue) {
+        [self willChangeValueForKey:BibKey(controlValue)];
+        _controlValue = [controlValue copy] ?: @"";
+        [self didChangeValueForKey:BibKey(controlValue)];
+    }
+}
+
+- (void)setFirstIndicator:(BibFieldIndicator *)firstIndicator {
+    if (_firstIndicator != firstIndicator) {
+        [self willChangeValueForKey:BibKey(firstIndicator)];
+        _firstIndicator = [firstIndicator copy] ?: [BibFieldIndicator new];
+        [self didChangeValueForKey:BibKey(firstIndicator)];
+    }
+}
+
+- (void)setSecondIndicator:(BibFieldIndicator *)secondIndicator {
+    if (_secondIndicator != secondIndicator) {
+        [self willChangeValueForKey:BibKey(secondIndicator)];
+        _secondIndicator = [secondIndicator copy] ?: [BibFieldIndicator new];
+        [self didChangeValueForKey:BibKey(secondIndicator)];
+    }
+}
+
+- (void)setSubfields:(NSArray<BibSubfield *> *)subfields {
+    if (_subfields != subfields) {
+        [self willChangeValueForKey:BibKey(subfields)];
+        _subfields = [subfields mutableCopy] ?: [NSMutableArray new];
+        [self didChangeValueForKey:BibKey(subfields)];
+    }
+}
+
+@end
+
+@implementation BibMutableRecordField (SubfieldAccess)
+
+- (void)addSubfield:(BibSubfield *)subfield {
+    [self insertSubfield:subfield atIndex:_subfields.count];
+}
+
+- (void)removeSubfield:(BibSubfield *)subfield {
+    NSUInteger const index = [_subfields indexOfObject:subfield];
+    if (index != NSNotFound) {
+        NSIndexSet *const indexes = [[NSIndexSet alloc] initWithIndex:index];
+        [self willChange:NSKeyValueChangeRemoval valuesAtIndexes:indexes forKey:BibKey(subfields)];
+        [_subfields removeObjectAtIndex:index];
+        [self willChange:NSKeyValueChangeRemoval valuesAtIndexes:indexes forKey:BibKey(subfields)];
+    }
+}
+
+- (void)insertSubfield:(BibSubfield *)subfield atIndex:(NSUInteger)index {
+    NSIndexSet *const indexes = [[NSIndexSet alloc] initWithIndex:_subfields.count];
+    [self willChange:NSKeyValueChangeInsertion valuesAtIndexes:indexes forKey:BibKey(subfields)];
+    [_subfields insertObject:[subfield copy] atIndex:index];
+    [self didChange:NSKeyValueChangeInsertion valuesAtIndexes:indexes forKey:BibKey(subfields)];
+}
+
+- (void)replaceSubfieldAtIndex:(NSUInteger)index withSubfield:(BibSubfield *)subfield {
+    NSIndexSet *const indexes = [[NSIndexSet alloc] initWithIndex:_subfields.count];
+    [self willChange:NSKeyValueChangeReplacement valuesAtIndexes:indexes forKey:BibKey(subfields)];
+    [_subfields replaceObjectAtIndex:index withObject:[subfield copy]];
+    [self didChange:NSKeyValueChangeReplacement valuesAtIndexes:indexes forKey:BibKey(subfields)];
+}
+
+- (void)setSubfield:(BibSubfield *)subfield atIndex:(NSUInteger)index {
+    [self replaceSubfieldAtIndex:index withSubfield:subfield];
+}
+
+- (void)setObject:(BibSubfield *)subfield atIndexedSubscript:(NSUInteger)index {
+    [self replaceSubfieldAtIndex:index withSubfield:subfield];
+}
+
+@end
+
+#pragma mark - Mutable Field Specialization
+
+@implementation _BibMutableRecordNofield
+
+- (BOOL)isControlField { return NO; }
+- (BOOL)isDataField { return NO; }
+- (NSString *)controlValue { return nil; }
+- (BibFieldIndicator *)firstIndicator { return nil; }
+- (BibFieldIndicator *)secondIndicator { return nil; }
+- (NSArray<BibSubfield *> *)subfields { return nil; }
+
+- (NSUInteger)subfieldCount { return 0; }
+- (BibSubfield *)subfieldAtIndex:(NSUInteger)index { return [[NSArray new] objectAtIndex:index]; }
+
+- (void)setFieldTag:(BibFieldTag *)fieldTag {
+    if (_fieldTag != fieldTag) {
+        [self willChangeValueForKey:BibKey(fieldTag)];
+        _fieldTag = [fieldTag copy];
+        if ([fieldTag isDataTag]) {
+            object_setClass(self, [_BibMutableRecordDatafield self]);
+            self->_firstIndicator = [BibFieldIndicator new];
+            self->_secondIndicator = [BibFieldIndicator new];
+            self->_subfields = [NSMutableArray new];
+        } else if ([fieldTag isControlTag]) {
+            object_setClass(self, [_BibMutableRecordControlfield self]);
+            self->_controlValue = @"";
+        }
+        [self didChangeValueForKey:BibKey(fieldTag)];
+    }
+}
+
+- (void)setControlValue:(NSString *)controlValue {}
+- (void)setFirstIndicator:(NSString *)firstIndicator {}
+- (void)setSecondIndicator:(NSString *)secondIndicator {}
+- (void)setSubfields:(NSArray<BibSubfield *> *)subfields {}
+
+- (void)addSubfield:(BibSubfield *)subfield {}
+- (void)removeSubfield:(BibSubfield *)subfield {}
+- (void)insertSubfield:(BibSubfield *)subfield atIndex:(NSUInteger)index {}
+- (void)replaceSubfieldAtIndex:(NSUInteger)index withSubfield:(BibSubfield *)subfield {}
+
+@end
+
+@implementation _BibMutableRecordDatafield
+
+- (BOOL)isControlField { return NO; }
+- (BOOL)isDataField { return YES; }
+- (NSString *)controlValue { return nil; }
+- (BibFieldIndicator *)firstIndicator { return _firstIndicator; }
+- (BibFieldIndicator *)secondIndicator { return _secondIndicator; }
+- (NSArray<BibSubfield *> *)subfields { return [_subfields copy]; }
+
+- (NSUInteger)subfieldCount { return _subfields.count; }
+- (BibSubfield *)subfieldAtIndex:(NSUInteger)index { return [_subfields objectAtIndex:index]; }
+
+- (void)setFieldTag:(BibFieldTag *)fieldTag {
+    if (_fieldTag != fieldTag) {
+        [self willChangeValueForKey:BibKey(fieldTag)];
+        _fieldTag = [fieldTag copy];
+        if ([fieldTag isDataTag]) {
+        } else if ([fieldTag isControlTag]) {
+            object_setClass(self, [_BibMutableRecordControlfield self]);
+            self->_controlValue = @"";
+            self->_firstIndicator = nil;
+            self->_secondIndicator = nil;
+            self->_subfields = nil;
+        } else {
+            object_setClass(self, [_BibMutableRecordNofield self]);
+            self->_firstIndicator = nil;
+            self->_secondIndicator = nil;
+            self->_subfields = nil;
+        }
+        [self didChangeValueForKey:BibKey(fieldTag)];
+    }
+}
+
+- (void)setControlValue:(NSString *)controlValue {}
+
+@end
+
+@implementation _BibMutableRecordControlfield
+
+- (BOOL)isControlField { return YES; }
+- (BOOL)isDataField { return NO; }
+- (NSString *)controlValue { return _controlValue ?: @""; }
+- (BibFieldIndicator *)firstIndicator { return nil; }
+- (BibFieldIndicator *)secondIndicator { return nil; }
+- (NSArray<BibSubfield *> *)subfields { return nil; }
+
+- (NSUInteger)subfieldCount { return 0; }
+- (BibSubfield *)subfieldAtIndex:(NSUInteger)index { return [[NSArray new] objectAtIndex:index]; }
+
+- (void)setFieldTag:(BibFieldTag *)fieldTag {
+    if (_fieldTag != fieldTag) {
+        [self willChangeValueForKey:BibKey(fieldTag)];
+        _fieldTag = [fieldTag copy];
+        if ([fieldTag isDataTag]) {
+            object_setClass(self, [_BibMutableRecordDatafield self]);
+            self->_controlValue = nil;
+            self->_firstIndicator = [BibFieldIndicator new];
+            self->_secondIndicator = [BibFieldIndicator new];
+            self->_subfields = [NSMutableArray new];
+        } else if ([fieldTag isControlTag]) {
+        } else {
+            object_setClass(self, [_BibMutableRecordNofield self]);
+            self->_controlValue = nil;
+        }
+        [self didChangeValueForKey:BibKey(fieldTag)];
+    }
+}
+
+- (void)setFirstIndicator:(BibFieldIndicator *)firstIndicator {}
+- (void)setSecondIndicator:(BibFieldIndicator *)secondIndicator {}
+- (void)setSubfields:(NSArray<BibSubfield *> *)subfields {}
+
+- (void)addSubfield:(BibSubfield *)subfield {}
+- (void)removeSubfield:(BibSubfield *)subfield {}
+- (void)insertSubfield:(BibSubfield *)subfield atIndex:(NSUInteger)index {}
+- (void)replaceSubfieldAtIndex:(NSUInteger)index withSubfield:(BibSubfield *)subfield {}
+
+@end

--- a/Bibliotek/Record/RecordField/FieldIndicator.swift
+++ b/Bibliotek/Record/RecordField/FieldIndicator.swift
@@ -1,0 +1,131 @@
+//
+//  FieldIndicator.swift
+//  Bibliotek
+//
+//  Created by Steve Brunwasser on 6/20/20.
+//  Copyright © 2020 Steve Brunwasser. All rights reserved.
+//
+
+import Foundation
+
+/// A metadata value assigning some semantic meaning to a data field.
+///
+/// Indicators are backed by an ASCII space character, an ASCII lowercase letter, or an ASCII number.
+/// Indicators are genally considered "blank" or "empty" when backed by an ASCII space character, but that value
+/// may also have some meaning depending on the semantic definition of the field.
+///
+/// More information about MARC 21 records can be found in the Library of Congress's documentation on
+/// MARC 21 Record Structure: https://www.loc.gov/marc/specifications/specrecstruc.html
+public struct FieldIndicator: RawRepresentable {
+    public typealias RawValue = CChar
+
+    /// The ASCII value of this indicator.
+    public var rawValue: CChar
+
+    /// Create an indicator with the given raw value.
+    /// \param rawValue An ASCII space, lowercase letter, or number.
+    /// \returns An indicator object with some semantic metadata meaning about a data field.
+    /// \note This method will throw an out-of-bounds exception for invalid indicator characters.
+    public init(rawValue: CChar) {
+        guard FieldIndicator.validRawValues.contains(rawValue) else {
+            fatalError("Invalid indicator character \(UnicodeScalar(UInt8(rawValue)))")
+        }
+        self.rawValue = rawValue
+    }
+
+    /// An indicator backed by an ASCII space character.
+    ///
+    /// "Blank" indicators generally represent the absence of an assigned value, but may also be considered ameaningful
+    /// meaningful depending on the semantic definition of the field.
+    public static let blank: FieldIndicator = " "
+
+    private static let validRawValues: Set<CChar> =
+        ([CChar(Character(" ").asciiValue!)] as Set)
+            .union(CChar(Character("0").asciiValue!) ... CChar(Character("9").asciiValue!))
+            .union(CChar(Character("a").asciiValue!) ... CChar(Character("z").asciiValue!))
+}
+
+extension FieldIndicator: Hashable, Equatable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.rawValue)
+    }
+
+    public static func == (lhs: FieldIndicator, rhs: FieldIndicator) -> Bool {
+        return lhs.rawValue == rhs.rawValue
+    }
+}
+
+extension FieldIndicator: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(CChar.self)
+        self.init(rawValue: rawValue)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
+    }
+}
+
+extension FieldIndicator: ExpressibleByUnicodeScalarLiteral {
+    public typealias UnicodeScalarLiteralType = UnicodeScalar
+
+    public init(unicodeScalarLiteral value: UnicodeScalar) {
+        guard let asciiValue = Character(value).asciiValue else {
+            fatalError("Invalid indicator character \(value)")
+        }
+        self.init(rawValue: CChar(asciiValue))
+    }
+}
+
+extension FieldIndicator: CustomStringConvertible, CustomDebugStringConvertible, CustomPlaygroundDisplayConvertible {
+    public var description: String {
+        let character = Character(UnicodeScalar(UInt8(self.rawValue)))
+        return (character == " ") ? "␢" : "\(character)"
+    }
+
+    public var debugDescription: String { return self.description }
+
+    public var playgroundDescription: Any { return self.description }
+}
+
+// MARK: - Bridging
+
+extension FieldIndicator: _ObjectiveCBridgeable {
+    public typealias _ObjectiveCType = BibFieldIndicator
+
+    @_semantics("convertToObjectiveC")
+    public func _bridgeToObjectiveC() -> BibFieldIndicator {
+        return BibFieldIndicator(rawValue: self.rawValue)
+    }
+
+    public static func _conditionallyBridgeFromObjectiveC(_ source: BibFieldIndicator, result: inout FieldIndicator?) -> Bool {
+        result = FieldIndicator(rawValue: source.rawValue)
+        return true
+    }
+
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: BibFieldIndicator?) -> FieldIndicator {
+        return FieldIndicator(rawValue: source!.rawValue)
+    }
+
+    public static func _forceBridgeFromObjectiveC(_ source: BibFieldIndicator, result: inout FieldIndicator?) {
+        result = FieldIndicator(rawValue: source.rawValue)
+    }
+}
+
+extension BibFieldIndicator: RawRepresentable, ExpressibleByUnicodeScalarLiteral, CustomPlaygroundDisplayConvertible {
+    public typealias UnicodeScalarLiteralType = UnicodeScalar
+
+    public required convenience init(unicodeScalarLiteral value: UnicodeScalar) {
+        guard let asciiValue = Character(value).asciiValue else {
+            fatalError("Invalid indicator character \(value)")
+        }
+        self.init(rawValue: CChar(asciiValue))
+    }
+
+    public var playgroundDescription: Any {
+        return self.description
+    }
+}

--- a/Bibliotek/Record/RecordField/RecordField.swift
+++ b/Bibliotek/Record/RecordField/RecordField.swift
@@ -1,0 +1,370 @@
+//
+//  RecordField.swift
+//  Bibliotek
+//
+//  Created by Steve Brunwasser on 6/20/20.
+//  Copyright © 2020 Steve Brunwasser. All rights reserved.
+//
+
+import Foundation
+
+/// A set of information and/or metadata about the item represented by a MARC record.
+///
+/// The semantic meaning of a record field is indicated by its `tag` value.
+/// A control field contains information and metadata about how a record's content should be processed.
+///
+/// The semantic meaning of a data field is indicated by its `tag` value, and its indicators are used as flags
+/// that determine how the data in its subfields should be interpreted or displayed.
+///
+/// Data fields are composed of `subfields`, which are portions of data semantically identified by their `code`.
+/// The interpretation of data within a content field is often determined by the formatting of its subfields' contents.
+/// For example, a bibliographic record's title statement, identified with the tag `245`, formats its content using
+/// ISBD principles and uses subfield codes to semantically tag each piece of the full statement.
+///
+/// You can read more about ISBD on its Wikipedia page:
+/// https://en.wikipedia.org/wiki/International_Standard_Bibliographic_Description
+///
+/// The ISBD punctuation standard can be found in section A3 in this consolidated technical specification:
+/// https://www.ifla.org/files/assets/cataloguing/isbd/isbd-cons_20110321.pdf
+///
+/// More information about MARC 21 records can be found in the Library of Congress's documentation on
+/// MARC 21 Record Structure: https://www.loc.gov/marc/specifications/specrecstruc.html
+public struct RecordField {
+
+    /// A value indicating the semantic purpose of the record field.
+    public var tag: FieldTag {
+        willSet { self.resetContentIfNeeded(forFieldTag: newValue) }
+    }
+
+    private(set) public var content: Content!
+
+    public enum Content {
+        case control(value: String)
+        case data(indicators: (first: FieldIndicator, second: FieldIndicator), subfields: [Subfield])
+    }
+    
+    /// This object is a control field containing a control value.
+    public var isControlField: Bool {
+        guard case .control(value: _) = self.content else { return false }
+        return true
+    }
+
+    /// This object is a data field with contnet indicators and subfield data.
+    public var isDataField: Bool {
+        guard case .data(indicators: _, subfields: _) = self.content else { return false }
+        return true
+    }
+
+    /// The information contained within the control field.
+    ///
+    /// - note: This value is  `nil` for data fields.
+    /// - note: This value is never  `nil` for control fields.
+    ///         Setting it to  `nil` will change its value to the empty string.
+    public var controlValue: String? {
+        get {
+            guard case let .control(value: value) = self.content else { return nil }
+            return value
+        }
+        set {
+            guard case .control(value: _) = self.content else { return }
+            self.content = .control(value: newValue ?? "")
+        }
+    }
+
+    /// The first and second metadata values in a data field, that can provide some semantic meaning to the field.
+    ///
+    /// - note: This value is  `nil` for control fields.
+    /// - note: This value is never  `nil` for data fields.
+    ///         Setting it to  `nil` will change its value to the blank indicator.
+    public var indicators: (first:  FieldIndicator, second: FieldIndicator)? {
+        get {
+            guard case let .data(indicators: indicators, subfields: _) = self.content else { return nil }
+            return indicators
+        }
+        set {
+            guard case let .data(indicators: _, subfields: subfields) = self.content else { return }
+            self.content = .data(indicators: newValue ?? (first: .blank, second: .blank), subfields: subfields)
+        }
+    }
+
+    /// An ordered list of subfields containing portions of data semantically identified by their `code`.
+    /// The interpretation of data within a content field is often determined by the formatting of its subfields' contents.
+    /// For example, a bibliographic record's title statement, identified with the tag `245`, formats its content using
+    /// ISBD principles and uses subfield codes to semantically tag each piece of the full statement.
+    ///
+    /// You can read more about ISBD on its Wikipedia page:
+    /// https://en.wikipedia.org/wiki/International_Standard_Bibliographic_Description
+    ///
+    /// The ISBD punctuation standard can be found in section A3 in this consolidated technical specification:
+    /// https://www.ifla.org/files/assets/cataloguing/isbd/isbd-cons_20110321.pdf
+    ///
+    /// - note: This value is `nil` for control fields.
+    /// - note: This value is never `nil` for data fields.
+    ///         Setting it to `nil` will change its value to an empty array.
+    public var subfields: [Subfield]? {
+        get {
+            guard case let .data(indicators: _, subfields: subfields) = self.content else { return nil }
+            return subfields
+        }
+        set {
+            guard case let .data(indicators: indicators, subfields: _) = self.content else { return }
+            self.content = .data(indicators: indicators, subfields: newValue ?? [])
+        }
+    }
+
+    private init(tag: FieldTag, content: Content?) {
+        self.tag = tag
+        self.content = content
+    }
+
+    /// Create an empty record field with the given record field tag.
+    /// - parameter fieldTag: The field tag identifying the semantic purpose for the new record field.
+    /// - returns: An empty record field object.
+    public init(tag: FieldTag) {
+        if tag.isDataTag {
+            self.init(tag: tag, content: .data(indicators: (first: .blank, second: .blank), subfields: []))
+        } else if tag.isControlTag {
+            self.init(tag: tag, content: .control(value: ""))
+        } else {
+            self.init(tag: tag, content: nil)
+        }
+    }
+
+    /// Create an empty record field with the given record field tag.
+    /// - parameter fieldTag: The field tag identifying the semantic purpose for the new record field.
+    /// - parameter controlValue: The control value for the field.
+    /// - returns: An control field object.
+    public init(tag: FieldTag, controlValue: String) {
+        guard tag.isControlTag else { self.init(tag: tag); return }
+        self.init(tag: tag, content: .control(value: controlValue))
+    }
+
+    /// Create an empty record field with the given record field tag.
+    /// - parameter fieldTag: The field tag identifying the semantic purpose for the new record field.
+    /// - parameter indicators: The first and second indicator values for a data field.
+    /// - parameter subfields: A list of subfields for a data field.
+    /// - returns: A data field object.
+    public init(tag: FieldTag, indicators: (first: FieldIndicator, second: FieldIndicator), subfields: [Subfield]) {
+        guard tag.isDataTag else { self.init(tag: tag); return }
+        self.init(tag: tag, content: .data(indicators: indicators, subfields: subfields))
+    }
+}
+
+extension RecordField {
+    private mutating func resetContentIfNeeded(forFieldTag tag: FieldTag) {
+        switch self.content {
+        case nil:
+            if tag.isDataTag {
+                self.content = .data(indicators: (first: .blank, second: .blank), subfields: [])
+            } else if tag.isControlTag {
+                self.content = .control(value: "")
+            }
+        case .control(value: _):
+            if tag.isDataTag {
+                self.content = .data(indicators: (first: .blank, second: .blank), subfields: [])
+            } else if !tag.isControlTag {
+                self.content = nil
+            }
+        case .data(indicators: _, subfields: _):
+            if tag.isControlTag {
+                self.content = .control(value: "")
+            } else if !tag.isDataTag {
+                self.content = nil
+            }
+        }
+    }
+}
+
+extension RecordField: Hashable, Equatable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.tag)
+        switch self.content {
+        case let .control(value: value):
+            hasher.combine(value)
+        case let .data(indicators: indicators, subfields: subfields):
+            hasher.combine(indicators.first)
+            hasher.combine(indicators.second)
+            hasher.combine(subfields)
+        case nil:
+            break
+        }
+    }
+
+    public static func == (lhs: RecordField, rhs: RecordField) -> Bool {
+        guard lhs.tag == rhs.tag else {
+            return false
+        }
+
+        switch lhs.content {
+        case let .control(value: lhsValue):
+            guard case let .control(value: rhsValue) = rhs.content else {
+                return false
+            }
+            return lhsValue == rhsValue
+
+        case let .data(indicators: lhsIndicators, subfields: lhsSubfields):
+            guard case let .data(indicators: rhsIndicators, subfields: rhsSubfields) = rhs.content else {
+                return false
+            }
+            return lhsIndicators.first == rhsIndicators.first
+                && lhsIndicators.second == rhsIndicators.second
+                && lhsSubfields == rhsSubfields
+
+        case nil:
+            return rhs.content == nil
+        }
+    }
+}
+
+extension RecordField: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode([FieldTag : RecordField.Content].self)
+        let tag = value.keys.first!
+        self.init(tag: tag, content: value[tag]!)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        guard let content = self.content else { return }
+        try container.encode([self.tag : content])
+    }
+}
+
+extension RecordField.Content: Codable {
+    /// - note: This structure exists to facilitate encoding and decoding with the MARC-in-JSON format.
+    /// https://rossfsinger.com/blog/2010/09/a-proposal-to-serialize-marc-in-json/
+    private struct DataFieldContent: Codable {
+        var firstIndicator: FieldIndicator
+        var secondIndicator: FieldIndicator
+        var subfields: [Subfield]
+
+        enum CodingKeys: String, CodingKey {
+            case firstIndicator = "ind1"
+            case secondIndicator = "ind2"
+            case subfields
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let controlValue = try? container.decode(String.self) {
+            self = .control(value: controlValue)
+        } else {
+            let dataFieldContent = try container.decode(DataFieldContent.self)
+            self = .data(indicators: (first: dataFieldContent.firstIndicator,
+                                      second: dataFieldContent.secondIndicator),
+                         subfields: dataFieldContent.subfields)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case let .control(value: value):
+            try container.encode(value)
+        case let .data(indicators: indicators, subfields: subfields):
+            let dataFieldContent = DataFieldContent(firstIndicator: indicators.first,
+                                                    secondIndicator: indicators.second,
+                                                    subfields: subfields)
+            try container.encode(dataFieldContent)
+        }
+    }
+}
+
+extension RecordField: CustomStringConvertible, CustomDebugStringConvertible, CustomPlaygroundDisplayConvertible {
+    public var description: String {
+        switch self.content {
+        case let .control(value: value): return value
+        case let .data(indicators: _, subfields: subfields): return subfields.map { "\($0)" }.joined(separator: " ")
+        default: return ""
+        }
+    }
+
+    public var debugDescription: String {
+        switch self.content {
+            case let .control(value: value):
+                return "\(self.tag) \(value)"
+            case let .data(indicators: indicators, subfields: subfields):
+                let content = subfields.map { "$\($0.code)\($0.content)" }.joined()
+                return "\(self.tag) \(indicators.first)\(indicators.second) \(content)"
+            default:
+                return "\(self.tag)"
+        }
+    }
+
+    public var playgroundDescription: Any {
+        switch self.content {
+        case let .control(value: value):
+            return ["tag" : self.tag,
+                    "control value" : value]
+        case let .data(indicators: indicators, subfields: subfields):
+            return ["tag" : self.tag,
+                    "indicators" : indicators,
+                    "subfields" : subfields]
+        default:
+            return ["tag" : self.tag]
+        }
+    }
+}
+
+// MARK: - Bridging
+
+extension RecordField: _ObjectiveCBridgeable {
+    public typealias _ObjectiveCType = BibRecordField
+
+    public func _bridgeToObjectiveC() -> BibRecordField {
+        switch self.content {
+        case nil:
+            return BibRecordField(fieldTag: self.tag as BibFieldTag)
+        case let .control(value: value):
+            return BibRecordField(fieldTag: self.tag as BibFieldTag, controlValue: value)
+        case let .data(indicators: indicators, subfields: subfields):
+            return BibRecordField(fieldTag: self.tag as BibFieldTag,
+                                  firstIndicator: indicators.first as BibFieldIndicator,
+                                  secondIndicator: indicators.second as BibFieldIndicator,
+                                  subfields: subfields as [BibSubfield])
+        }
+    }
+
+    public static func _forceBridgeFromObjectiveC(_ source: BibRecordField, result: inout RecordField?) {
+        if source.isControlField {
+            result = RecordField(tag: source.fieldTag as FieldTag, controlValue: source.controlValue!)
+        } else if source.isDataField {
+            result = RecordField(tag: source.fieldTag as FieldTag,
+                                 indicators: (first: source.firstIndicator! as FieldIndicator,
+                                              second: source.secondIndicator! as FieldIndicator),
+                                 subfields: source.subfields! as [Subfield])
+        } else {
+            result = .init(tag: source.fieldTag as FieldTag)
+        }
+    }
+
+    public static func _conditionallyBridgeFromObjectiveC(_ source: BibRecordField, result: inout RecordField?) -> Bool {
+        self._forceBridgeFromObjectiveC(source, result: &result)
+        return true
+    }
+
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: BibRecordField?) -> RecordField {
+        guard let source = source else { return RecordField(tag: "000") }
+        var result: RecordField!
+        self._forceBridgeFromObjectiveC(source, result: &result)
+        return result
+    }
+}
+
+extension BibRecordField: CustomPlaygroundDisplayConvertible {
+    public var playgroundDescription: Any {
+        if self.isDataField {
+            return ["fieldTag" : self.fieldTag,
+                    "firstIndicator" : self.firstIndicator!,
+                    "secondIndicator" : self.secondIndicator!,
+                    "subfields" : self.subfields!]
+        } else if self.isControlField {
+            return ["fieldTag" : self.fieldTag,
+                    "controlValue" : self.controlValue!]
+        } else {
+            return ["fieldTag" : self.fieldTag]
+        }
+    }
+}

--- a/Bibliotek/Record/RecordField/RecordField.swift
+++ b/Bibliotek/Record/RecordField/RecordField.swift
@@ -216,6 +216,30 @@ extension RecordField: Hashable, Equatable {
     }
 }
 
+extension RecordField {
+    public func subfield(with code: SubfieldCode) -> Subfield? {
+        return self.indexOfSubfiled(with: code).map(self.subfield(at:))
+    }
+
+    public func indexOfSubfiled(with code: SubfieldCode) -> Int? {
+        switch self.content {
+        case nil, .control(value: _):
+            return nil
+
+        case let .data(indicators: _, subfields: subfields):
+            return subfields.indices.first(where: { subfields[$0].code == code })
+        }
+    }
+
+    public func subfield(at index: Int) -> Subfield {
+        return self.subfields![index]
+    }
+
+    public func containsSubfield(with code: SubfieldCode) -> Bool {
+        return self.indexOfSubfiled(with: code) != nil
+    }
+}
+
 extension RecordField: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()

--- a/Bibliotek/Record/RecordField/RecordField.swift
+++ b/Bibliotek/Record/RecordField/RecordField.swift
@@ -217,10 +217,24 @@ extension RecordField: Hashable, Equatable {
 }
 
 extension RecordField {
+    /// The total amount of subfields contained in this data field.
+    /// - note: This value is always `0` for control fields.
+    public var subfieldCount: Int { return self.subfields?.count ?? 0 }
+
+    /// Get the first subfield marked with the given code.
+    /// - parameter code: The subfield code that the resulting subfield should have.
+    /// - returns: The first subfield in this data field with the given subfield code.
+    ///            `nil` is returned if there is no such matching subfield.
+    /// - note: This method always returns `nil` for control fields.
     public func subfield(with code: SubfieldCode) -> Subfield? {
         return self.indexOfSubfiled(with: code).map(self.subfield(at:))
     }
 
+    /// Get the index of the first subfield marked with the given code.
+    /// - parameter subfieldCode: The subfield code that the resulting subfield should have.
+    /// - returns: The index of the first subfield in this data field with the given subfield code.
+    ///            `nil` is returned if there is no such matching subfield.
+    /// - note: This method always returns `nil` for control fields.
     public func indexOfSubfiled(with code: SubfieldCode) -> Int? {
         switch self.content {
         case nil, .control(value: _):
@@ -231,10 +245,28 @@ extension RecordField {
         }
     }
 
+    /// Get this data field's subfield at the given index.
+    /// - parameter index: The index of the subfield to access.
+    /// - returns: This data field's subfiled located at the given index.
+    /// - note: This method will fatally error for control fields.
     public func subfield(at index: Int) -> Subfield {
         return self.subfields![index]
     }
 
+    /// Use indexed subscripting syntax to access a subfield from this data field.
+    /// - parameter index: The index of the subfield to access.
+    /// - returns: This data field's subfiled located at the given index.
+    /// - note: This method will throw fatally error for control fields.
+    public subscript(index: Int) -> Subfield {
+        get { return self.subfield(at: index) }
+        set { self.subfields![index] = newValue }
+    }
+
+    /// Check to see if this data field has a subfield marked with the given code.
+    /// - parameter subfieldCode: The subfield code used to check the presence of any relevant subfields.
+    /// - returns: `true` when this data field contains a subfield marked with the given code.
+    ///            `false` is returned when no such subfield is found.
+    /// - note: This method always returns `false` for control fields.
     public func containsSubfield(with code: SubfieldCode) -> Bool {
         return self.indexOfSubfiled(with: code) != nil
     }

--- a/BibliotekTests/BibMARCInputStreamTests.m
+++ b/BibliotekTests/BibMARCInputStreamTests.m
@@ -31,14 +31,17 @@
     XCTAssertNil(error);
     XCTAssertNotNil(record);
     BibFieldTag *const titleStatementFieldTag = [[BibFieldTag alloc] initWithString:@"153"];
-    BibContentField *const field = [[record contentFieldsWithTag:titleStatementFieldTag] firstObject];
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"a"] content], @"KJV5461.3");
-    NSUInteger const firstIndex = [[field subfields] indexOfObject:[field firstSubfieldWithCode:@"h"]];
-    XCTAssertEqualObjects([[[field subfields] objectAtIndex:firstIndex] content], @"Law of France");
-    XCTAssertEqualObjects([[[field subfields] objectAtIndex:firstIndex + 1] content],
+    BibRecordField *const field = [record fieldWithTag:titleStatementFieldTag];
+    NSUInteger const indexOfSubfieldA = [field indexOfSubfieldWithCode:@"a"];
+    XCTAssertNotEqual(indexOfSubfieldA, NSNotFound);
+    XCTAssertEqualObjects([[field subfieldAtIndex:indexOfSubfieldA] content], @"KJV5461.3");
+    NSUInteger const indexOfSubfieldH = [field indexOfSubfieldWithCode:@"h"];
+    XCTAssertNotEqual(indexOfSubfieldH, NSNotFound);
+    XCTAssertEqualObjects([[field subfieldAtIndex:indexOfSubfieldH] content], @"Law of France");
+    XCTAssertEqualObjects([[field subfieldAtIndex:indexOfSubfieldH + 1] content],
                           @"Cultural affairs. L'action culturelle des pouvoirs publics");
-    XCTAssertEqualObjects([[[field subfields] objectAtIndex:firstIndex + 2] content], @"Education");
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"j"] content], @"Private schools");
+    XCTAssertEqualObjects([[field subfieldAtIndex:indexOfSubfieldH + 2] content], @"Education");
+    XCTAssertEqualObjects([[field subfieldWithCode:@"j"] content], @"Private schools");
 }
 
 - (void)testReadBibliographicRecord {
@@ -48,12 +51,12 @@
     XCTAssertNil(error);
     XCTAssertNotNil(record);
     BibFieldTag *const titleStatementFieldTag = [[BibFieldTag alloc] initWithString:@"245"];
-    BibContentField *const field = [[record contentFieldsWithTag:titleStatementFieldTag] firstObject];
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"a"] content], @"In the land of invented languages :");
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"b"] content], @"Esperanto rock stars, Klingon poets, "
-                                                                        @"Loglan lovers, and the mad dreamers "
-                                                                        @"who tried to build a perfect language /");
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"c"] content], @"Arika Okrent.");
+    BibRecordField *const field = [record fieldWithTag:titleStatementFieldTag];
+    XCTAssertEqualObjects([[field subfieldWithCode:@"a"] content], @"In the land of invented languages :");
+    XCTAssertEqualObjects([[field subfieldWithCode:@"b"] content], @"Esperanto rock stars, Klingon poets, "
+                                                                   @"Loglan lovers, and the mad dreamers "
+                                                                   @"who tried to build a perfect language /");
+    XCTAssertEqualObjects([[field subfieldWithCode:@"c"] content], @"Arika Okrent.");
 
 }
 

--- a/BibliotekTests/BibMARCSerializationInput.m
+++ b/BibliotekTests/BibMARCSerializationInput.m
@@ -41,14 +41,14 @@
     BibRecord *const record = records.firstObject;
     XCTAssertNotNil(record);
     BibFieldTag *const titleStatementFieldTag = [[BibFieldTag alloc] initWithString:@"153"];
-    BibContentField *const field = [[record contentFieldsWithTag:titleStatementFieldTag] firstObject];
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"a"] content], @"KJV5461.3");
-    NSUInteger const firstIndex = [[field subfields] indexOfObject:[field firstSubfieldWithCode:@"h"]];
-    XCTAssertEqualObjects([[[field subfields] objectAtIndex:firstIndex] content], @"Law of France");
-    XCTAssertEqualObjects([[[field subfields] objectAtIndex:firstIndex + 1] content],
+    BibRecordField *const field = [[record allFieldsWithTag:titleStatementFieldTag] firstObject];
+    XCTAssertEqualObjects([[field subfieldWithCode:@"a"] content], @"KJV5461.3");
+    NSUInteger const firstIndex = [field indexOfSubfieldWithCode:@"h"];
+    XCTAssertEqualObjects([[field subfieldAtIndex:firstIndex] content], @"Law of France");
+    XCTAssertEqualObjects([[field subfieldAtIndex:firstIndex + 1] content],
                           @"Cultural affairs. L'action culturelle des pouvoirs publics");
-    XCTAssertEqualObjects([[[field subfields] objectAtIndex:firstIndex + 2] content], @"Education");
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"j"] content], @"Private schools");
+    XCTAssertEqualObjects([[field subfieldAtIndex:firstIndex + 2] content], @"Education");
+    XCTAssertEqualObjects([[field subfieldWithCode:@"j"] content], @"Private schools");
 }
 
 - (void)testReadClassificationRecordFromInputStream {
@@ -58,14 +58,14 @@
     XCTAssertNil(error);
     XCTAssertNotNil(record);
     BibFieldTag *const titleStatementFieldTag = [[BibFieldTag alloc] initWithString:@"153"];
-    BibContentField *const field = [[record contentFieldsWithTag:titleStatementFieldTag] firstObject];
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"a"] content], @"KJV5461.3");
-    NSUInteger const firstIndex = [[field subfields] indexOfObject:[field firstSubfieldWithCode:@"h"]];
-    XCTAssertEqualObjects([[[field subfields] objectAtIndex:firstIndex] content], @"Law of France");
-    XCTAssertEqualObjects([[[field subfields] objectAtIndex:firstIndex + 1] content],
+    BibRecordField *const field = [[record allFieldsWithTag:titleStatementFieldTag] firstObject];
+    XCTAssertEqualObjects([[field subfieldWithCode:@"a"] content], @"KJV5461.3");
+    NSUInteger const firstIndex = [field indexOfSubfieldWithCode:@"h"];
+    XCTAssertEqualObjects([[field subfieldAtIndex:firstIndex] content], @"Law of France");
+    XCTAssertEqualObjects([[field subfieldAtIndex:firstIndex + 1] content],
                           @"Cultural affairs. L'action culturelle des pouvoirs publics");
-    XCTAssertEqualObjects([[[field subfields] objectAtIndex:firstIndex + 2] content], @"Education");
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"j"] content], @"Private schools");
+    XCTAssertEqualObjects([[field subfieldAtIndex:firstIndex + 2] content], @"Education");
+    XCTAssertEqualObjects([[field subfieldWithCode:@"j"] content], @"Private schools");
 }
 
 - (void)testReadBibliographicRecordFromData {
@@ -77,12 +77,12 @@
     BibRecord *const record = records.firstObject;
     XCTAssertNotNil(record);
     BibFieldTag *const titleStatementFieldTag = [[BibFieldTag alloc] initWithString:@"245"];
-    BibContentField *const field = [[record contentFieldsWithTag:titleStatementFieldTag] firstObject];
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"a"] content], @"In the land of invented languages :");
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"b"] content], @"Esperanto rock stars, Klingon poets, "
-                                                                        @"Loglan lovers, and the mad dreamers "
-                                                                        @"who tried to build a perfect language /");
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"c"] content], @"Arika Okrent.");
+    BibRecordField *const field = [[record allFieldsWithTag:titleStatementFieldTag] firstObject];
+    XCTAssertEqualObjects([[field subfieldWithCode:@"a"] content], @"In the land of invented languages :");
+    XCTAssertEqualObjects([[field subfieldWithCode:@"b"] content], @"Esperanto rock stars, Klingon poets, "
+                                                                   @"Loglan lovers, and the mad dreamers "
+                                                                   @"who tried to build a perfect language /");
+    XCTAssertEqualObjects([[field subfieldWithCode:@"c"] content], @"Arika Okrent.");
 }
 
 - (void)testReadBibliographicRecordFromInputStream {
@@ -92,12 +92,12 @@
     XCTAssertNil(error);
     XCTAssertNotNil(record);
     BibFieldTag *const titleStatementFieldTag = [[BibFieldTag alloc] initWithString:@"245"];
-    BibContentField *const field = [[record contentFieldsWithTag:titleStatementFieldTag] firstObject];
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"a"] content], @"In the land of invented languages :");
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"b"] content], @"Esperanto rock stars, Klingon poets, "
-                                                                        @"Loglan lovers, and the mad dreamers "
-                                                                        @"who tried to build a perfect language /");
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"c"] content], @"Arika Okrent.");
+    BibRecordField *const field = [[record allFieldsWithTag:titleStatementFieldTag] firstObject];
+    XCTAssertEqualObjects([[field subfieldWithCode:@"a"] content], @"In the land of invented languages :");
+    XCTAssertEqualObjects([[field subfieldWithCode:@"b"] content], @"Esperanto rock stars, Klingon poets, "
+                                                                   @"Loglan lovers, and the mad dreamers "
+                                                                   @"who tried to build a perfect language /");
+    XCTAssertEqualObjects([[field subfieldWithCode:@"c"] content], @"Arika Okrent.");
 }
 
 #pragma mark -
@@ -109,8 +109,8 @@
     XCTAssertNil(error);
     XCTAssertNotNil(record);
     BibFieldTag *const classificationFieldNumberTag = [[BibFieldTag alloc] initWithString:@"153"];
-    BibContentField *const field = [[record contentFieldsWithTag:classificationFieldNumberTag] firstObject];
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"j"] content], @"K\x6F\xCC\x88nig, Josef, 1893-1974");
+    BibRecordField *const field = [[record allFieldsWithTag:classificationFieldNumberTag] firstObject];
+    XCTAssertEqualObjects([[field subfieldWithCode:@"j"] content], @"K\x6F\xCC\x88nig, Josef, 1893-1974");
 }
 
 - (void)testConversionFromMARC8Encoding2 {
@@ -120,8 +120,8 @@
     XCTAssertNil(error);
     XCTAssertNotNil(record);
     BibFieldTag *const classificationFieldNumberTag = [[BibFieldTag alloc] initWithString:@"153"];
-    BibContentField *const field = [[record contentFieldsWithTag:classificationFieldNumberTag] firstObject];
-    XCTAssertEqualObjects([[field firstSubfieldWithCode:@"a"] content], @"E585.I75");
+    BibRecordField *const field = [[record allFieldsWithTag:classificationFieldNumberTag] firstObject];
+    XCTAssertEqualObjects([[field subfieldWithCode:@"a"] content], @"E585.I75");
 }
 
 

--- a/BibliotekTests/BibliotekTests.swift
+++ b/BibliotekTests/BibliotekTests.swift
@@ -95,10 +95,11 @@ class BibliotekTests: XCTestCase {
             XCTAssertEqual(rs.count, 1)
             guard let record = rs.first else { return XCTFail("Failure to fetch record by ISBN") }
             XCTAssertTrue(record.kind?.isBibliographicKind ?? false)
-            let isbn13Field = record.contentFields.first(where: { $0.tag == "020" })
+            let isbn13Field = record.fields.first(where: { $0.tag == "020" })
             XCTAssertNotNil(isbn13Field)
-            XCTAssertEqual(isbn13Field?.subfields.count, 1)
-            let isbn13 = isbn13Field?.subfields.first(where: { $0.code == "a" }).map { $0.content }
+            XCTAssertTrue(isbn13Field?.isDataField == true)
+            XCTAssertEqual(isbn13Field?.subfields?.count, 1)
+            let isbn13 = isbn13Field?.subfields?.first(where: { $0.code == "a" }).map { $0.content }
             XCTAssertNotNil(isbn13)
             XCTAssertEqual(isbn13, r.keywords.first!)
         } catch {

--- a/BibliotekTests/RecordFieldAccessTests.swift
+++ b/BibliotekTests/RecordFieldAccessTests.swift
@@ -25,9 +25,9 @@ class RecordFieldAccessTests: XCTestCase {
         XCTAssertEqual(indexPaths.count, 1, "Expected one control number field")
         XCTAssertEqual(indexPaths.first!.count, 1, "Index paths for fields should have only one index")
 
-        let fields = indexPaths.compactMap(self.record.controlField(at:))
+        let fields = indexPaths.compactMap(self.record.field(at:)).filter { $0.isControlField }
         XCTAssertEqual(fields.count, indexPaths.count, "Expected a control field for all index paths")
-        XCTAssertEqual(fields.first!.value, "15434749")
+        XCTAssertEqual(fields.first!.controlValue, "15434749")
 
         let fieldContents = indexPaths.map(self.record.content(at:))
         XCTAssertEqual(fieldContents.count, indexPaths.count, "Expected content for all index paths")
@@ -40,10 +40,10 @@ class RecordFieldAccessTests: XCTestCase {
         XCTAssertEqual(indexPaths.first!.count, 1, "Index paths for fields should have only one index")
         XCTAssertEqual(indexPaths.last!.count, 1, "Index paths for fields should have only one index")
 
-        let fields = indexPaths.compactMap(self.record.contentField(at:))
-        XCTAssertEqual(fields.count, indexPaths.count, "Expected a content field for all index paths")
-        XCTAssertEqual(fields.first!.subfields.map(\.content).joined(), "9780385527880")
-        XCTAssertEqual(fields.last!.subfields.map(\.content).joined(), "0385527888")
+        let fields = indexPaths.compactMap(self.record.field(at:)).filter { $0.isDataField }
+        XCTAssertEqual(fields.count, indexPaths.count, "Expected a data field for all index paths")
+        XCTAssertEqual(fields.first!.subfields!.map(\.content).joined(), "9780385527880")
+        XCTAssertEqual(fields.last!.subfields!.map(\.content).joined(), "0385527888")
 
         let fieldContents = indexPaths.map(self.record.content(at:))
         XCTAssertEqual(fieldContents.count, indexPaths.count, "Expected content for all index paths")


### PR DESCRIPTION
`BibRecordField` allows us to model control fields and data fields using the same interface, which should simplify accessing record fields across massive amounts of records. Now we're able to index control fields, data fields, and subfields uniformly using index paths—without needing to keep track of which indexes point to control fields vs data fields.

This change also introduces a convention change away from using the term "content fields" in favor of "data fields", which is used in the Library of Congress's specification for MARC 21 records.